### PR TITLE
Handle missing cfitsio on pkg-config path

### DIFF
--- a/fitsio-sys/build.rs
+++ b/fitsio-sys/build.rs
@@ -1,6 +1,32 @@
 extern crate pkg_config;
 
+use std::io::Write;
+use pkg_config::Error;
+
 fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
-    pkg_config::probe_library("cfitsio").unwrap();
+
+    let package_name = "cfitsio";
+    match pkg_config::probe_library(package_name) {
+        Ok(_) => {}
+        Err(Error::Failure { output, .. }) => {
+            // Handle the case where the user has not installed cfitsio, and thusly it is not on
+            // the PKG_CONFIG_PATH
+            let stderr = String::from_utf8(output.stderr).unwrap();
+            if stderr.contains::<&str>(format!("{} was not found in the pkg-config search path",
+                                               package_name)
+                .as_ref()) {
+                let err_msg = format!("
+Cannot find {} on the pkg-config search path.  Consider installing the library for your
+system (e.g. through homebrew, apt-get etc.).  Alternatively if it is installed, then add
+the directory that contains `cfitsio.pc` on your PKG_CONFIG_PATH, e.g.:
+
+PKG_CONFIG_PATH=<blah> cargo build
+",
+                                      package_name);
+                std::io::stderr().write(err_msg.as_bytes()).unwrap();
+                std::process::exit(output.status.code().unwrap());
+            }
+        }
+        Err(e) => panic!("Unhandled error: {:?}", e),
+    };
 }


### PR DESCRIPTION
If the `fitsio-sys` build script cannot find `cfitsio` with `pkg-config`, it throws a horrible message (see #10). This change handles this case by printing a slightly more friendly error message.

The implementation is a little hacky - I was just trying to follow the compiler's advice and hence may not be very idiomatic rust, but it works...