### PR TITLE
Swap order of FitsFile and FitsHdu objects in method calls

### DIFF
--- a/fitsio/src/fitsfile.rs
+++ b/fitsio/src/fitsfile.rs
@@ -441,6 +441,251 @@ impl FitsFile {
         T::write_key(self, name, value)
     }
 
+    /// Write contiguous data to a fits image
+    ///
+    /// Returns the new HDU object
+    pub fn write_section<T: ReadWriteImage>(
+        &mut self,
+        hdu: &FitsHdu,
+        start: usize,
+        end: usize,
+        data: &[T],
+    ) -> Result<FitsHdu> {
+        self.make_current(hdu)?;
+        fits_check_readwrite!(self);
+        T::write_section(self, start, end, data)
+    }
+
+
+
+    /// Read an image between pixel a and pixel b into a `Vec`
+    pub fn read_section<T: ReadWriteImage>(
+        &mut self,
+        hdu: &FitsHdu,
+        start: usize,
+        end: usize,
+    ) -> Result<Vec<T>> {
+        self.make_current(hdu)?;
+        T::read_section(self, start, end)
+    }
+
+    /// Read a binary table column
+    pub fn read_col<T: ReadsCol>(&mut self, hdu: &FitsHdu, name: &str) -> Result<Vec<T>> {
+        self.make_current(hdu)?;
+        T::read_col(self, name)
+    }
+
+
+    /// Read part of a column, within a range
+    pub fn read_col_range<T: ReadsCol>(
+        &mut self,
+        hdu: &FitsHdu,
+        name: &str,
+        range: &Range<usize>,
+    ) -> Result<Vec<T>> {
+        self.make_current(hdu)?;
+        T::read_col_range(self, name, range)
+    }
+
+    /// Iterate over the columns in a fits file
+    pub fn columns<'a>(&'a mut self, hdu: &FitsHdu) -> ColumnIterator<'a> {
+        self.make_current(hdu).expect("Cannot make hdu current");
+        ColumnIterator::new(self)
+    }
+
+    /// Write a binary table column
+    pub fn write_col<T: WritesCol, N: Into<String>>(
+        &mut self,
+        hdu: &FitsHdu,
+        name: N,
+        col_data: &[T],
+    ) -> Result<FitsHdu> {
+        self.make_current(hdu)?;
+        fits_check_readwrite!(self);
+        T::write_col(self, hdu, name, col_data)
+    }
+
+    /// Write part of a column, within a range
+    pub fn write_col_range<T: WritesCol, N: Into<String>>(
+        &mut self,
+        hdu: &FitsHdu,
+        name: N,
+        col_data: &[T],
+        rows: &Range<usize>,
+    ) -> Result<FitsHdu> {
+        self.make_current(hdu)?;
+        fits_check_readwrite!(self);
+        T::write_col_range(self, hdu, name, col_data, rows)
+    }
+
+    /// Read a whole fits image into a vector
+    pub fn read_image<T: ReadWriteImage>(&mut self, hdu: &FitsHdu) -> Result<Vec<T>> {
+        self.make_current(hdu)?;
+        T::read_image(self)
+    }
+
+    /// Read multiple rows from a fits image
+    pub fn read_rows<T: ReadWriteImage>(
+        &mut self,
+        hdu: &FitsHdu,
+        start_row: usize,
+        num_rows: usize,
+    ) -> Result<Vec<T>> {
+        self.make_current(hdu)?;
+        T::read_rows(self, start_row, num_rows)
+    }
+
+
+    /// Read a single row from a fits image
+    pub fn read_row<T: ReadWriteImage>(&mut self, hdu: &FitsHdu, row: usize) -> Result<Vec<T>> {
+        self.make_current(hdu)?;
+        T::read_row(self, row)
+    }
+
+    /// Write a rectangular region to a fits image
+    pub fn write_region<T: ReadWriteImage>(
+        &mut self,
+        hdu: &FitsHdu,
+        ranges: &[&Range<usize>],
+        data: &[T],
+    ) -> Result<FitsHdu> {
+        self.make_current(hdu)?;
+        fits_check_readwrite!(self);
+        T::write_region(self, ranges, data)
+    }
+
+    /// Read a square region into a `Vec`
+    pub fn read_region<T: ReadWriteImage>(
+        &mut self,
+        hdu: &FitsHdu,
+        ranges: &[&Range<usize>],
+    ) -> Result<Vec<T>> {
+        self.make_current(hdu)?;
+        T::read_region(self, ranges)
+    }
+
+    /// Resize a HDU image
+    ///
+    /// The `new_size` parameter defines the new size of the image. This can be any length, but
+    /// only 2D images are supported at the moment
+    pub fn resize(&mut self, hdu: FitsHdu, new_size: &[usize]) -> Result<FitsHdu> {
+        // TODO(srw): does this make sense to belong on the fits file object?
+        self.make_current(&hdu)?;
+        fits_check_readwrite!(self);
+
+        assert_eq!(new_size.len(), 2);
+        match hdu.info {
+            HduInfo::ImageInfo { image_type, .. } => {
+                let mut status = 0;
+                unsafe {
+                    sys::ffrsim(
+                        self.fptr as *mut _,
+                        image_type.into(),
+                        2,
+                        new_size.as_ptr() as *mut _,
+                        &mut status,
+                    );
+                }
+                check_status(status).and_then(|_| self.current_hdu())
+            }
+            HduInfo::TableInfo { .. } => Err("cannot resize binary table".into()),
+            HduInfo::AnyInfo => unreachable!(),
+        }
+
+    }
+
+
+    /// Return a pointer to the underlying C `fitsfile` object representing the current file.
+    ///
+    /// This is marked as `unsafe` as it is definitely something that is not required by most
+    /// users, and hence the unsafe-ness marks it as an advanced feature. I have also not
+    /// considered possible concurrency or data race issues as yet.
+    // XXX This may have to be wrapped in some form of access control structure, such as an
+    // `std::rc::Rc`.
+    pub unsafe fn as_raw(&self) -> *mut sys::fitsfile {
+        self.fptr as *mut _
+    }
+
+    /// Insert a column into a fits table
+    ///
+    /// The column location is 0-indexed. It is inserted _at_ that position, and the following
+    /// columns are shifted back.
+    pub fn insert_column(
+        &mut self,
+        hdu: &FitsHdu,
+        position: usize,
+        description: &ConcreteColumnDescription,
+    ) -> Result<FitsHdu> {
+        self.make_current(hdu)?;
+        fits_check_readwrite!(self);
+
+        let mut status = 0;
+
+        let c_name = ffi::CString::new(description.name.clone())?;
+        let c_type = ffi::CString::new(String::from(description.data_type.clone()))?;
+
+        unsafe {
+            sys::fficol(
+                self.fptr as *mut _,
+                (position + 1) as _,
+                c_name.into_raw(),
+                c_type.into_raw(),
+                &mut status,
+            );
+        }
+
+        check_status(status).and_then(|_| self.current_hdu())
+    }
+
+    /// Add a new column to the end of the table
+    pub fn append_column(
+        &mut self,
+        hdu: &FitsHdu,
+        description: &ConcreteColumnDescription,
+    ) -> Result<FitsHdu> {
+        self.make_current(hdu)?;
+        fits_check_readwrite!(self);
+
+        /* We have to split up the fetching of the number of columns from the inserting of the
+         * new column, as otherwise we're trying move out of self */
+        let result = match hdu.info {
+            HduInfo::TableInfo { ref column_descriptions, .. } => Ok(column_descriptions.len()),
+            HduInfo::ImageInfo { .. } => Err("Cannot add columns to FITS image".into()),
+            HduInfo::AnyInfo { .. } => {
+                Err("Cannot determine HDU type, so cannot add columns".into())
+            }
+        };
+
+        match result {
+            Ok(colno) => self.insert_column(hdu, colno, description),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Remove a column from the fits file
+    ///
+    /// The column can be identified by id or name.
+    pub fn delete_column<T: DescribesColumnLocation>(
+        &mut self,
+        hdu: &FitsHdu,
+        col_identifier: T,
+    ) -> Result<FitsHdu> {
+        self.make_current(hdu)?;
+        fits_check_readwrite!(self);
+
+        let colno = T::get_column_no(&col_identifier, hdu, self)?;
+        let mut status = 0;
+
+        unsafe {
+            sys::ffdcol(self.fptr as *mut _, (colno + 1) as _, &mut status);
+        }
+
+        check_status(status).and_then(|_| self.current_hdu())
+    }
+
+    /// Return the index for a given column.
+    ///
+    /// Internal method, not exposed.
     fn get_column_no<T: Into<String>>(&mut self, hdu: &FitsHdu, col_name: T) -> Result<usize> {
         self.make_current(hdu)?;
 
@@ -464,243 +709,21 @@ impl FitsFile {
         check_status(status).map(|_| (colno - 1) as usize)
     }
 
-    /*
-    /// Read an image between pixel a and pixel b into a `Vec`
-    pub fn read_section<T: ReadWriteImage>(
-        &self,
-        fits_file: &mut FitsFile,
-        start: usize,
-        end: usize,
-    ) -> Result<Vec<T>> {
-        fits_file.make_current(self)?;
-        T::read_section(fits_file, start, end)
-    }
-
-
-    /// Read multiple rows from a fits image
-    pub fn read_rows<T: ReadWriteImage>(
-        &self,
-        fits_file: &mut FitsFile,
-        start_row: usize,
-        num_rows: usize,
-    ) -> Result<Vec<T>> {
-        fits_file.make_current(self)?;
-        T::read_rows(fits_file, start_row, num_rows)
-    }
-
-    /// Read a single row from a fits image
-    pub fn read_row<T: ReadWriteImage>(
-        &self,
-        fits_file: &mut FitsFile,
-        row: usize,
-    ) -> Result<Vec<T>> {
-        fits_file.make_current(self)?;
-        T::read_row(fits_file, row)
-    }
-
-    /// Read a whole fits image into a vector
-    pub fn read_image<T: ReadWriteImage>(&self, fits_file: &mut FitsFile) -> Result<Vec<T>> {
-        fits_file.make_current(self)?;
-        T::read_image(fits_file)
-    }
-
-    /// Write contiguous data to a fits image
-    ///
-    /// Returns the new HDU object
-    pub fn write_section<T: ReadWriteImage>(
-        self,
-        fits_file: &mut FitsFile,
-        start: usize,
-        end: usize,
-        data: &[T],
-    ) -> Result<FitsHdu> {
-        fits_file.make_current(&self)?;
-        fits_check_readwrite!(fits_file);
-        T::write_section(fits_file, start, end, data)
-    }
-
-    /// Write a rectangular region to a fits image
-    pub fn write_region<T: ReadWriteImage>(
-        self,
-        fits_file: &mut FitsFile,
-        ranges: &[&Range<usize>],
-        data: &[T],
-    ) -> Result<FitsHdu> {
-        fits_file.make_current(&self)?;
-        fits_check_readwrite!(fits_file);
-        T::write_region(fits_file, ranges, data)
-    }
-
-    /// Read a square region into a `Vec`
-    pub fn read_region<T: ReadWriteImage>(
-        &self,
-        fits_file: &mut FitsFile,
-        ranges: &[&Range<usize>],
-    ) -> Result<Vec<T>> {
-        fits_file.make_current(self)?;
-        T::read_region(fits_file, ranges)
-    }
-
-
-    /// Return a pointer to the underlying C `fitsfile` object representing the current file.
-    ///
-    /// This is marked as `unsafe` as it is definitely something that is not required by most
-    /// users, and hence the unsafe-ness marks it as an advanced feature. I have also not
-    /// considered possible concurrency or data race issues as yet.
-    // XXX This may have to be wrapped in some form of access control structure, such as an
-    // `std::rc::Rc`.
-    pub unsafe fn as_raw(&self) -> *mut sys::fitsfile {
-        self.fptr as *mut _
-    }
-
-    /// Insert a column into a fits table
-    ///
-    /// The column location is 0-indexed. It is inserted _at_ that position, and the following
-    /// columns are shifted back.
-    pub fn insert_column(
-        self,
-        fits_file: &mut FitsFile,
-        position: usize,
-        description: &ConcreteColumnDescription,
-    ) -> Result<FitsHdu> {
-        fits_file.make_current(&self)?;
-        fits_check_readwrite!(fits_file);
-
-        let mut status = 0;
-
-        let c_name = ffi::CString::new(description.name.clone())?;
-        let c_type = ffi::CString::new(String::from(description.data_type.clone()))?;
-
-        unsafe {
-            sys::fficol(
-                fits_file.fptr as *mut _,
-                (position + 1) as _,
-                c_name.into_raw(),
-                c_type.into_raw(),
-                &mut status,
-            );
-        }
-
-        check_status(status).and_then(|_| fits_file.current_hdu())
-    }
-
-
-    /// Add a new column to the end of the table
-    pub fn append_column(
-        self,
-        fits_file: &mut FitsFile,
-        description: &ConcreteColumnDescription,
-    ) -> Result<FitsHdu> {
-        fits_file.make_current(&self)?;
-        fits_check_readwrite!(fits_file);
-
-        /* We have to split up the fetching of the number of columns from the inserting of the
-         * new column, as otherwise we're trying move out of self */
-        let result = match self.info {
-            HduInfo::TableInfo { ref column_descriptions, .. } => Ok(column_descriptions.len()),
-            HduInfo::ImageInfo { .. } => Err("Cannot add columns to FITS image".into()),
-            HduInfo::AnyInfo { .. } => {
-                Err("Cannot determine HDU type, so cannot add columns".into())
-            }
-        };
-
-        match result {
-            Ok(colno) => self.insert_column(fits_file, colno, description),
-            Err(e) => Err(e),
-        }
-    }
-
-    /// Remove a column from the fits file
-    ///
-    /// The column can be identified by id or name.
-    pub fn delete_column<T: DescribesColumnLocation>(
-        self,
-        fits_file: &mut FitsFile,
-        col_identifier: T,
-    ) -> Result<FitsHdu> {
-        fits_file.make_current(&self)?;
-        fits_check_readwrite!(fits_file);
-
-        let colno = T::get_column_no(&col_identifier, &self, fits_file)?;
-        let mut status = 0;
-
-        unsafe {
-            sys::ffdcol(fits_file.fptr as *mut _, (colno + 1) as _, &mut status);
-        }
-
-        check_status(status).and_then(|_| fits_file.current_hdu())
-    }
-
-    /// Return the index for a given column.
-    ///
-    /// Internal method, not exposed.
-
-
-    /// Read a binary table column
-    pub fn read_col<T: ReadsCol>(&self, fits_file: &mut FitsFile, name: &str) -> Result<Vec<T>> {
-        fits_file.make_current(self)?;
-        T::read_col(fits_file, name)
-    }
-
-    /// Read part of a column, within a range
-    pub fn read_col_range<T: ReadsCol>(
-        &self,
-        fits_file: &mut FitsFile,
-        name: &str,
-        range: &Range<usize>,
-    ) -> Result<Vec<T>> {
-        fits_file.make_current(self)?;
-        T::read_col_range(fits_file, name, range)
-    }
-
-    /// Write a binary table column
-    pub fn write_col<T: WritesCol, N: Into<String>>(
-        &self,
-        fits_file: &mut FitsFile,
-        name: N,
-        col_data: &[T],
-    ) -> Result<FitsHdu> {
-        fits_file.make_current(&self)?;
-        fits_check_readwrite!(fits_file);
-        T::write_col(fits_file, &self, name, col_data)
-    }
-
-    /// Write part of a column, within a range
-    pub fn write_col_range<T: WritesCol, N: Into<String>>(
-        &self,
-        fits_file: &mut FitsFile,
-        name: N,
-        col_data: &[T],
-        rows: &Range<usize>,
-    ) -> Result<FitsHdu> {
-        fits_file.make_current(&self)?;
-        fits_check_readwrite!(fits_file);
-        T::write_col_range(fits_file, &self, name, col_data, rows)
-    }
-
-    /// Iterate over the columns in a fits file
-    pub fn columns<'a>(&self, fits_file: &'a mut FitsFile) -> ColumnIterator<'a> {
-        fits_file.make_current(self).expect(
-            "Cannot make hdu current",
-        );
-        ColumnIterator::new(fits_file)
-    }
 
     /// Delete the current HDU from the fits file.
     ///
     /// Note this method takes `self` by value, and as such the hdu cannot be used after this
     /// method is called.
-    pub fn delete(self, fits_file: &mut FitsFile) -> Result<()> {
-        fits_file.make_current(&self)?;
+    pub fn delete(mut self, hdu: FitsHdu) -> Result<()> {
+        self.make_current(&hdu)?;
 
         let mut status = 0;
         let mut curhdu = 0;
         unsafe {
-            sys::ffdhdu(fits_file.fptr as *mut _, &mut curhdu, &mut status);
+            sys::ffdhdu(self.fptr as *mut _, &mut curhdu, &mut status);
         }
         check_status(status).map(|_| ())
     }
-*/
 }
 
 impl Drop for FitsFile {
@@ -1626,35 +1649,6 @@ impl FitsHdu {
     }
 
 
-    /// Resize a HDU image
-    ///
-    /// The `new_size` parameter defines the new size of the image. This can be any length, but
-    /// only 2D images are supported at the moment.
-    pub fn resize(self, fits_file: &mut FitsFile, new_size: &[usize]) -> Result<FitsHdu> {
-        fits_file.make_current(&self)?;
-        fits_check_readwrite!(fits_file);
-
-        assert_eq!(new_size.len(), 2);
-        match self.info {
-            HduInfo::ImageInfo { image_type, .. } => {
-                let mut status = 0;
-                unsafe {
-                    sys::ffrsim(
-                        fits_file.fptr as *mut _,
-                        image_type.into(),
-                        2,
-                        new_size.as_ptr() as *mut _,
-                        &mut status,
-                    );
-                }
-                check_status(status).and_then(|_| fits_file.current_hdu())
-            }
-            HduInfo::TableInfo { .. } => Err("cannot resize binary table".into()),
-            HduInfo::AnyInfo => unreachable!(),
-        }
-
-    }
-
     /// Copy an HDU to another open fits file
     pub fn copy_to(
         &self,
@@ -1718,7 +1712,7 @@ mod test {
         });
     }
 
-    /*
+
     #[test]
     fn opening_an_existing_file() {
         match FitsFile::open("../testdata/full_example.fits") {
@@ -1736,7 +1730,7 @@ mod test {
 
                     // Ensure the empty primary has been written
                     let hdu = f.hdu(0).unwrap();
-                    let naxis: i64 = hdu.read_key(&mut f, "NAXIS").unwrap();
+                    let naxis: i64 = f.read_key(&hdu, "NAXIS").unwrap();
                     assert_eq!(naxis, 0);
                 })
                 .unwrap();
@@ -1784,15 +1778,13 @@ mod test {
                 let image_hdu = f.hdu(0).unwrap();
 
                 let data_to_write: Vec<i64> = (0..100).map(|_| 10101).collect();
-                image_hdu
-                    .write_section(&mut f, 0, 100, &data_to_write)
-                    .unwrap();
+                f.write_section(&image_hdu, 0, 100, &data_to_write).unwrap();
             }
 
             {
                 let mut f = FitsFile::open(filename).unwrap();
                 let hdu = f.hdu(0).unwrap();
-                let read_data: Vec<i64> = hdu.read_section(&mut f, 0, 10).unwrap();
+                let read_data: Vec<i64> = f.read_section(&hdu, 0, 10).unwrap();
                 assert_eq!(read_data, vec![10101; 10]);
             }
         });
@@ -1968,7 +1960,7 @@ mod test {
         let hdu = f.current_hdu().unwrap();
 
         assert_eq!(
-            hdu.read_key::<String>(&mut f, "EXTNAME").unwrap(),
+            f.read_key::<String>(&hdu, "EXTNAME").unwrap(),
             "TESTEXT".to_string()
         );
     }
@@ -2002,7 +1994,7 @@ mod test {
             let hdu: FitsHdu = f.create_image("foo".to_string(), &image_description)
                 .unwrap();
             assert_eq!(
-                hdu.read_key::<String>(&mut f, "EXTNAME").unwrap(),
+                f.read_key::<String>(&hdu, "EXTNAME").unwrap(),
                 "foo".to_string()
             );
         });
@@ -2023,7 +2015,7 @@ mod test {
             let hdu: FitsHdu = f.create_table("foo".to_string(), &table_description)
                 .unwrap();
             assert_eq!(
-                hdu.read_key::<String>(&mut f, "EXTNAME").unwrap(),
+                f.read_key::<String>(&hdu, "EXTNAME").unwrap(),
                 "foo".to_string()
             );
         });
@@ -2056,12 +2048,12 @@ mod test {
     fn reading_header_keys() {
         let mut f = FitsFile::open("../testdata/full_example.fits").unwrap();
         let hdu = f.hdu(0).unwrap();
-        match hdu.read_key::<i64>(&mut f, "INTTEST") {
+        match f.read_key::<i64>(&hdu, "INTTEST") {
             Ok(value) => assert_eq!(value, 42),
             Err(e) => panic!("Error reading key: {:?}", e),
         }
 
-        match hdu.read_key::<f64>(&mut f, "DBLTEST") {
+        match f.read_key::<f64>(&hdu, "DBLTEST") {
             Ok(value) => {
                 assert!(
                     floats_close_f64(value, 0.09375),
@@ -2073,7 +2065,7 @@ mod test {
             Err(e) => panic!("Error reading key: {:?}", e),
         }
 
-        match hdu.read_key::<String>(&mut f, "TEST") {
+        match f.read_key::<String>(&hdu, "TEST") {
             Ok(value) => assert_eq!(value, "value"),
             Err(e) => panic!("Error reading key: {:?}", e),
         }
@@ -2086,18 +2078,17 @@ mod test {
             // Scope ensures file is closed properly
             {
                 let mut f = FitsFile::create(filename).unwrap();
-                f.hdu(0).unwrap().write_key(&mut f, "FOO", 1i64).unwrap();
-                f.hdu(0)
-                    .unwrap()
-                    .write_key(&mut f, "BAR", "baz".to_string())
-                    .unwrap();
+                let hdu = f.hdu(0).unwrap();
+                f.write_key(&hdu, "FOO", 1i64).unwrap();
+                f.write_key(&hdu, "BAR", "baz".to_string()).unwrap();
             }
 
             FitsFile::open(filename)
                 .map(|mut f| {
-                    assert_eq!(f.hdu(0).unwrap().read_key::<i64>(&mut f, "foo").unwrap(), 1);
+                    let hdu = f.hdu(0).unwrap();
+                    assert_eq!(f.read_key::<i64>(&hdu, "foo").unwrap(), 1);
                     assert_eq!(
-                        f.hdu(0).unwrap().read_key::<String>(&mut f, "bar").unwrap(),
+                        f.read_key::<String>(&hdu, "bar").unwrap(),
                         "baz".to_string()
                     );
                 })
@@ -2119,12 +2110,12 @@ mod test {
     fn read_columns() {
         let mut f = FitsFile::open("../testdata/full_example.fits").unwrap();
         let hdu = f.hdu(1).unwrap();
-        let intcol_data: Vec<i32> = hdu.read_col(&mut f, "intcol").unwrap();
+        let intcol_data: Vec<i32> = f.read_col(&hdu, "intcol").unwrap();
         assert_eq!(intcol_data[0], 18);
         assert_eq!(intcol_data[15], 10);
         assert_eq!(intcol_data[49], 12);
 
-        let floatcol_data: Vec<f32> = hdu.read_col(&mut f, "floatcol").unwrap();
+        let floatcol_data: Vec<f32> = f.read_col(&hdu, "floatcol").unwrap();
         assert!(
             floats_close_f32(floatcol_data[0], 17.496801),
             "{:?} != {:?}",
@@ -2144,7 +2135,7 @@ mod test {
             10.217053
         );
 
-        let doublecol_data: Vec<f64> = hdu.read_col(&mut f, "doublecol").unwrap();
+        let doublecol_data: Vec<f64> = f.read_col(&hdu, "doublecol").unwrap();
         assert!(
             floats_close_f64(doublecol_data[0], 16.959972808730814),
             "{:?} != {:?}",
@@ -2169,7 +2160,7 @@ mod test {
     fn read_string_col() {
         let mut f = FitsFile::open("../testdata/full_example.fits").unwrap();
         let hdu = f.hdu(1).unwrap();
-        let strcol: Vec<String> = hdu.read_col(&mut f, "strcol").unwrap();
+        let strcol: Vec<String> = f.read_col(&hdu, "strcol").unwrap();
         assert_eq!(strcol.len(), 50);
         assert_eq!(strcol[0], "value0");
         assert_eq!(strcol[15], "value15");
@@ -2180,7 +2171,7 @@ mod test {
     fn read_column_regions() {
         let mut f = FitsFile::open("../testdata/full_example.fits").unwrap();
         let hdu = f.hdu(1).unwrap();
-        let intcol_data: Vec<i32> = hdu.read_col_range(&mut f, "intcol", &(0..2)).unwrap();
+        let intcol_data: Vec<i32> = f.read_col_range(&hdu, "intcol", &(0..2)).unwrap();
         assert_eq!(intcol_data.len(), 3);
         assert_eq!(intcol_data[0], 18);
         assert_eq!(intcol_data[1], 13);
@@ -2190,7 +2181,7 @@ mod test {
     fn read_string_column_regions() {
         let mut f = FitsFile::open("../testdata/full_example.fits").unwrap();
         let hdu = f.hdu(1).unwrap();
-        let intcol_data: Vec<String> = hdu.read_col_range(&mut f, "strcol", &(0..2)).unwrap();
+        let intcol_data: Vec<String> = f.read_col_range(&hdu, "strcol", &(0..2)).unwrap();
         assert_eq!(intcol_data.len(), 3);
         assert_eq!(intcol_data[0], "value0");
         assert_eq!(intcol_data[1], "value1");
@@ -2200,7 +2191,7 @@ mod test {
     fn read_column_region_check_ranges() {
         let mut f = FitsFile::open("../testdata/full_example.fits").unwrap();
         let hdu = f.hdu(1).unwrap();
-        let result_data: Result<Vec<i32>> = hdu.read_col_range(&mut f, "intcol", &(0..2_000_000));
+        let result_data: Result<Vec<i32>> = f.read_col_range(&hdu, "intcol", &(0..2_000_000));
         assert!(result_data.is_err());
     }
 
@@ -2210,7 +2201,7 @@ mod test {
 
         let mut f = FitsFile::open("../testdata/full_example.fits").unwrap();
         let hdu = f.hdu(1).unwrap();
-        let column_names: Vec<String> = hdu.columns(&mut f)
+        let column_names: Vec<String> = f.columns(&hdu)
             .map(|col| match col {
                 Column::Int32 { name, .. } => name,
                 Column::Int64 { name, .. } => name,
@@ -2235,9 +2226,9 @@ mod test {
     fn column_number() {
         let mut f = FitsFile::open("../testdata/full_example.fits").unwrap();
         let hdu = f.hdu("testext").unwrap();
-        assert_eq!(hdu.get_column_no(&mut f, "intcol").unwrap(), 0);
-        assert_eq!(hdu.get_column_no(&mut f, "floatcol").unwrap(), 1);
-        assert_eq!(hdu.get_column_no(&mut f, "doublecol").unwrap(), 2);
+        assert_eq!(f.get_column_no(&hdu, "intcol").unwrap(), 0);
+        assert_eq!(f.get_column_no(&hdu, "floatcol").unwrap(), 1);
+        assert_eq!(f.get_column_no(&hdu, "doublecol").unwrap(), 2);
     }
 
     #[test]
@@ -2257,12 +2248,12 @@ mod test {
                 let hdu = f.create_table("foo".to_string(), &table_description)
                     .unwrap();
 
-                hdu.write_col(&mut f, "bar", &data_to_write).unwrap();
+                f.write_col(&hdu, "bar", &data_to_write).unwrap();
             }
 
             let mut f = FitsFile::open(filename).unwrap();
             let hdu = f.hdu("foo").unwrap();
-            let data: Vec<i32> = hdu.read_col(&mut f, "bar").unwrap();
+            let data: Vec<i32> = f.read_col(&hdu, "bar").unwrap();
             assert_eq!(data, data_to_write);
         });
     }
@@ -2281,7 +2272,7 @@ mod test {
             let hdu = f.create_image("foo".to_string(), &image_description)
                 .unwrap();
 
-            match hdu.write_col(&mut f, "bar", &data_to_write) {
+            match f.write_col(&hdu, "bar", &data_to_write) {
                 Err(Error::Message(msg)) => {
                     assert_eq!(msg, "Cannot write column data to FITS image")
                 }
@@ -2307,13 +2298,13 @@ mod test {
                 let hdu = f.create_table("foo".to_string(), &table_description)
                     .unwrap();
 
-                hdu.write_col_range(&mut f, "bar", &data_to_write, &(0..5))
+                f.write_col_range(&hdu, "bar", &data_to_write, &(0..5))
                     .unwrap();
             }
 
             let mut f = FitsFile::open(filename).unwrap();
             let hdu = f.hdu("foo").unwrap();
-            let data: Vec<i32> = hdu.read_col(&mut f, "bar").unwrap();
+            let data: Vec<i32> = f.read_col(&hdu, "bar").unwrap();
             assert_eq!(data.len(), 6);
             assert_eq!(data[..], data_to_write[0..6]);
         });
@@ -2341,12 +2332,12 @@ mod test {
                 let hdu = f.create_table("foo".to_string(), &table_description)
                     .unwrap();
 
-                hdu.write_col(&mut f, "bar", &data_to_write).unwrap();
+                f.write_col(&hdu, "bar", &data_to_write).unwrap();
             }
 
             let mut f = FitsFile::open(filename).unwrap();
             let hdu = f.hdu("foo").unwrap();
-            let data: Vec<String> = hdu.read_col(&mut f, "bar").unwrap();
+            let data: Vec<String> = f.read_col(&hdu, "bar").unwrap();
             assert_eq!(data.len(), data_to_write.len());
             assert_eq!(data[0], "value0");
             assert_eq!(data[49], "value49");
@@ -2357,31 +2348,31 @@ mod test {
     fn read_image_data() {
         let mut f = FitsFile::open("../testdata/full_example.fits").unwrap();
         let hdu = f.hdu(0).unwrap();
-        let first_row: Vec<i32> = hdu.read_section(&mut f, 0, 100).unwrap();
+        let first_row: Vec<i32> = f.read_section(&hdu, 0, 100).unwrap();
         assert_eq!(first_row.len(), 100);
         assert_eq!(first_row[0], 108);
         assert_eq!(first_row[49], 176);
 
-        let second_row: Vec<i32> = hdu.read_section(&mut f, 100, 200).unwrap();
+        let second_row: Vec<i32> = f.read_section(&hdu, 100, 200).unwrap();
         assert_eq!(second_row.len(), 100);
         assert_eq!(second_row[0], 177);
         assert_eq!(second_row[49], 168);
     }
-
     #[test]
     fn read_whole_image() {
         let mut f = FitsFile::open("../testdata/full_example.fits").unwrap();
         let hdu = f.hdu(0).unwrap();
-        let image: Vec<i32> = hdu.read_image(&mut f).unwrap();
+        let image: Vec<i32> = f.read_image(&hdu).unwrap();
         assert_eq!(image.len(), 10000);
     }
+
 
     #[test]
     fn read_image_rows() {
         let mut f = FitsFile::open("../testdata/full_example.fits").unwrap();
         let hdu = f.hdu(0).unwrap();
-        let row: Vec<i32> = hdu.read_rows(&mut f, 0, 2).unwrap();
-        let ref_row: Vec<i32> = hdu.read_section(&mut f, 0, 200).unwrap();
+        let row: Vec<i32> = f.read_rows(&hdu, 0, 2).unwrap();
+        let ref_row: Vec<i32> = f.read_section(&hdu, 0, 200).unwrap();
         assert_eq!(row, ref_row);
     }
 
@@ -2389,8 +2380,8 @@ mod test {
     fn read_image_row() {
         let mut f = FitsFile::open("../testdata/full_example.fits").unwrap();
         let hdu = f.hdu(0).unwrap();
-        let row: Vec<i32> = hdu.read_row(&mut f, 0).unwrap();
-        let ref_row: Vec<i32> = hdu.read_section(&mut f, 0, 100).unwrap();
+        let row: Vec<i32> = f.read_row(&hdu, 0).unwrap();
+        let ref_row: Vec<i32> = f.read_section(&hdu, 0, 100).unwrap();
         assert_eq!(row, ref_row);
     }
 
@@ -2402,7 +2393,7 @@ mod test {
         let xcoord = 5..7;
         let ycoord = 2..3;
 
-        let chunk: Vec<i32> = hdu.read_region(&mut f, &vec![&ycoord, &xcoord]).unwrap();
+        let chunk: Vec<i32> = f.read_region(&hdu, &vec![&ycoord, &xcoord]).unwrap();
         assert_eq!(chunk.len(), 2 * 3);
         assert_eq!(chunk[0], 168);
         assert_eq!(chunk[chunk.len() - 1], 132);
@@ -2412,7 +2403,7 @@ mod test {
     fn read_image_region_from_table() {
         let mut f = FitsFile::open("../testdata/full_example.fits").unwrap();
         let hdu = f.hdu("TESTEXT").unwrap();
-        match hdu.read_region::<i32>(&mut f, &vec![&(0..10), &(0..10)]) {
+        match f.read_region::<i32>(&hdu, &vec![&(0..10), &(0..10)]) {
             Err(Error::Message(msg)) => {
                 assert!(msg.contains("cannot read image data from a table hdu"))
             }
@@ -2424,7 +2415,7 @@ mod test {
     fn read_image_section_from_table() {
         let mut f = FitsFile::open("../testdata/full_example.fits").unwrap();
         let hdu = f.hdu("TESTEXT").unwrap();
-        if let Err(Error::Message(msg)) = hdu.read_section::<i32>(&mut f, 0, 100) {
+        if let Err(Error::Message(msg)) = f.read_section::<i32>(&hdu, 0, 100) {
             assert!(msg.contains("cannot read image data from a table hdu"));
         } else {
             panic!("Should have been an error");
@@ -2447,12 +2438,12 @@ mod test {
                 };
                 let hdu = f.create_image("foo".to_string(), &image_description)
                     .unwrap();
-                hdu.write_section(&mut f, 0, 100, &data_to_write).unwrap();
+                f.write_section(&hdu, 0, 100, &data_to_write).unwrap();
             }
 
             let mut f = FitsFile::open(filename).unwrap();
             let hdu = f.hdu("foo").unwrap();
-            let first_row: Vec<i64> = hdu.read_section(&mut f, 0, 100).unwrap();
+            let first_row: Vec<i64> = f.read_section(&hdu, 0, 100).unwrap();
             assert_eq!(first_row, data_to_write);
 
         });
@@ -2474,13 +2465,12 @@ mod test {
                     .unwrap();
 
                 let data: Vec<i64> = (0..121).map(|v| v + 50).collect();
-                hdu.write_region(&mut f, &[&(0..10), &(0..10)], &data)
-                    .unwrap();
+                f.write_region(&hdu, &[&(0..10), &(0..10)], &data).unwrap();
             }
 
             let mut f = FitsFile::open(filename).unwrap();
             let hdu = f.hdu("foo").unwrap();
-            let chunk: Vec<i64> = hdu.read_region(&mut f, &[&(0..10), &(0..10)]).unwrap();
+            let chunk: Vec<i64> = f.read_region(&hdu, &[&(0..10), &(0..10)]).unwrap();
             assert_eq!(chunk.len(), 11 * 11);
             assert_eq!(chunk[0], 50);
             assert_eq!(chunk[25], 75);
@@ -2508,7 +2498,7 @@ mod test {
             {
                 let mut f = FitsFile::edit(filename).unwrap();
                 let hdu = f.hdu("foo").unwrap();
-                hdu.resize(&mut f, &[1024, 1024]).unwrap();
+                f.resize(hdu, &[1024, 1024]).unwrap();
             }
 
             /* Images are only resized when flushed to disk, so close the file and
@@ -2525,7 +2515,6 @@ mod test {
             }
         });
     }
-
     #[test]
     fn write_image_section_to_table() {
         with_temp_file(|filename| {
@@ -2542,7 +2531,7 @@ mod test {
             ];
             let hdu = f.create_table("foo".to_string(), table_description)
                 .unwrap();
-            if let Err(Error::Message(msg)) = hdu.write_section(&mut f, 0, 100, &data_to_write) {
+            if let Err(Error::Message(msg)) = f.write_section(&hdu, 0, 100, &data_to_write) {
                 assert_eq!(msg, "cannot write image data to a table hdu");
             } else {
                 panic!("Should have thrown an error");
@@ -2568,7 +2557,7 @@ mod test {
                 .unwrap();
 
             let ranges = vec![&(0..10), &(0..10)];
-            if let Err(Error::Message(msg)) = hdu.write_region(&mut f, &ranges, &data_to_write) {
+            if let Err(Error::Message(msg)) = f.write_region(&hdu, &ranges, &data_to_write) {
                 assert_eq!(msg, "cannot write image data to a table hdu");
             } else {
                 panic!("Should have thrown an error");
@@ -2584,12 +2573,12 @@ mod test {
         let primary_hdu = f.hdu(0).unwrap();
         let column_hdu = f.hdu(1).unwrap();
 
-        let first_row: Vec<i32> = primary_hdu.read_section(&mut f, 0, 100).unwrap();
+        let first_row: Vec<i32> = f.read_section(&primary_hdu, 0, 100).unwrap();
         assert_eq!(first_row.len(), 100);
         assert_eq!(first_row[0], 108);
         assert_eq!(first_row[49], 176);
 
-        let intcol_data: Vec<i32> = column_hdu.read_col(&mut f, "intcol").unwrap();
+        let intcol_data: Vec<i32> = f.read_col(&column_hdu, "intcol").unwrap();
         assert_eq!(intcol_data[0], 18);
         assert_eq!(intcol_data[49], 12);
     }
@@ -2637,7 +2626,7 @@ mod test {
         duplicate_test_file(|filename| {
             let mut f = FitsFile::edit(filename).unwrap();
             let hdu = f.hdu(0).unwrap();
-            let newhdu = hdu.resize(&mut f, &vec![1024, 1024]).unwrap();
+            let newhdu = f.resize(hdu, &vec![1024, 1024]).unwrap();
 
             match newhdu.info {
                 HduInfo::ImageInfo { shape, .. } => {
@@ -2670,7 +2659,7 @@ mod test {
                 .create()
                 .unwrap();
 
-            let newhdu = hdu.insert_column(&mut f, 0, &coldesc).unwrap();
+            let newhdu = f.insert_column(&hdu, 0, &coldesc).unwrap();
 
             match newhdu.info {
                 HduInfo::TableInfo { column_descriptions, .. } => {
@@ -2694,7 +2683,7 @@ mod test {
                 .create()
                 .unwrap();
 
-            let newhdu = hdu.append_column(&mut f, &coldesc).unwrap();
+            let newhdu = f.append_column(&hdu, &coldesc).unwrap();
 
             match newhdu.info {
                 HduInfo::TableInfo { column_descriptions, .. } => {
@@ -2713,7 +2702,7 @@ mod test {
         duplicate_test_file(|filename| {
             let mut f = FitsFile::edit(filename).unwrap();
             let hdu = f.hdu("TESTEXT").unwrap();
-            let newhdu = hdu.delete_column(&mut f, "intcol").unwrap();
+            let newhdu = f.delete_column(&hdu, "intcol").unwrap();
 
             match newhdu.info {
                 HduInfo::TableInfo { column_descriptions, .. } => {
@@ -2732,7 +2721,7 @@ mod test {
             {
                 let mut f = FitsFile::edit(filename).unwrap();
                 let hdu = f.hdu("TESTEXT").unwrap();
-                hdu.delete(&mut f).unwrap();
+                f.delete(hdu).unwrap();
             }
 
             let mut f = FitsFile::open(filename).unwrap();
@@ -2746,7 +2735,7 @@ mod test {
         duplicate_test_file(|filename| {
             let mut f = FitsFile::edit(filename).unwrap();
             let hdu = f.hdu("TESTEXT").unwrap();
-            let newhdu = hdu.delete_column(&mut f, 0).unwrap();
+            let newhdu = f.delete_column(&hdu, 0).unwrap();
 
             match newhdu.info {
                 HduInfo::TableInfo { column_descriptions, .. } => {
@@ -2772,5 +2761,4 @@ mod test {
             assert_eq!(counter, 2);
         });
     }
-    */
 }

--- a/fitsio/src/lib.rs
+++ b/fitsio/src/lib.rs
@@ -230,7 +230,7 @@
 //! # let mut dest_fptr = fitsio::FitsFile::create(filename.to_str().unwrap()).unwrap();
 //! #
 //! # let hdu = src_fptr.hdu(1).unwrap();
-//! hdu.copy_to(&mut src_fptr, &mut dest_fptr).unwrap();
+//! src_fptr.copy(hdu).to(&mut dest_fptr).unwrap();
 //! # }
 //! ```
 //!

--- a/fitsio/src/lib.rs
+++ b/fitsio/src/lib.rs
@@ -257,7 +257,7 @@
 //! # let hdu = fptr.create_image("EXTNAME".to_string(), &image_description).unwrap();
 //! // let fptr = FitsFile::open(...).unwrap();
 //! // let hdu = fptr.hdu(0).unwrap();
-//! hdu.delete(&mut fptr).unwrap();
+//! fptr.delete(hdu).unwrap();
 //! // Cannot use hdu after this
 //! # }
 //! ```
@@ -292,13 +292,14 @@
 //! # fn main() {
 //! # let filename = "../testdata/full_example.fits";
 //! # let mut fptr = fitsio::FitsFile::open(filename).unwrap();
+//! # let hdu = fptr.hdu(0).unwrap();
 //! # {
-//! let int_value: i64 = fptr.hdu(0).unwrap().read_key(&mut fptr, "INTTEST").unwrap();
+//! let int_value: i64 = fptr.read_key(&hdu, "INTTEST").unwrap();
 //! # }
 //!
 //! // Alternatively
 //! # {
-//! let int_value = fptr.hdu(0).unwrap().read_key::<i64>(&mut fptr, "INTTEST").unwrap();
+//! let int_value = fptr.read_key::<i64>(&hdu, "INTTEST").unwrap();
 //! # }
 //!
 //! // Or let the compiler infer the types (if possible)
@@ -317,8 +318,9 @@
 //! # let filename = tdir_path.join("test.fits");
 //! # {
 //! # let mut fptr = fitsio::FitsFile::create(filename.to_str().unwrap()).unwrap();
-//! fptr.hdu(0).unwrap().write_key(&mut fptr, "foo", 1i64).unwrap();
-//! assert_eq!(fptr.hdu(0).unwrap().read_key::<i64>(&mut fptr, "foo").unwrap(), 1i64);
+//! # let hdu = fptr.hdu(0).unwrap();
+//! fptr.write_key(&hdu, "foo", 1i64).unwrap();
+//! assert_eq!(fptr.read_key::<i64>(&hdu, "foo").unwrap(), 1i64);
 //! # }
 //! ```
 //!
@@ -340,13 +342,13 @@
 //! # let mut fptr = fitsio::FitsFile::open(filename).unwrap();
 //! # let hdu = fptr.hdu(0).unwrap();
 //! // Read the first 100 pixels
-//! let first_row: Vec<i32> = hdu.read_section(&mut fptr, 0, 100).unwrap();
+//! let first_row: Vec<i32> = fptr.read_section(&hdu, 0, 100).unwrap();
 //!
 //! // Read a square section of the image
 //!
 //! let xcoord = 0..10;
 //! let ycoord = 0..10;
-//! let chunk: Vec<i32> = hdu.read_region(&mut fptr, &[&ycoord, &xcoord]).unwrap();
+//! let chunk: Vec<i32> = fptr.read_region(&hdu, &[&ycoord, &xcoord]).unwrap();
 //! # }
 //! ```
 //!
@@ -362,7 +364,7 @@
 //! # let hdu = fptr.hdu(0).unwrap();
 //! let start_row = 0;
 //! let num_rows = 10;
-//! let first_few_rows: Vec<f32> = hdu.read_rows(&mut fptr, start_row, num_rows).unwrap();
+//! let first_few_rows: Vec<f32> = fptr.read_rows(&hdu, start_row, num_rows).unwrap();
 //!
 //! // 10 rows of 100 columns
 //! assert_eq!(first_few_rows.len(), 1000);
@@ -378,7 +380,7 @@
 //! # let filename = "../testdata/full_example.fits";
 //! # let mut fptr = fitsio::FitsFile::open(filename).unwrap();
 //! # let hdu = fptr.hdu(0).unwrap();
-//! let image_data: Vec<f32> = hdu.read_image(&mut fptr, ).unwrap();
+//! let image_data: Vec<f32> = fptr.read_image(&hdu).unwrap();
 //!
 //! // 100 rows of 100 columns
 //! assert_eq!(image_data.len(), 10_000);
@@ -397,8 +399,8 @@
 //! # fn main() {
 //! # let filename = "../testdata/full_example.fits";
 //! # let mut fptr = fitsio::FitsFile::open(filename).unwrap();
-//! # let hdu = fptr.hdu(1);
-//! let integer_data: Vec<i32> = hdu.and_then(|hdu| hdu.read_col(&mut fptr, "intcol")).unwrap();
+//! # let hdu = fptr.hdu(1).unwrap();
+//! let integer_data: Vec<i32> = fptr.read_col(&hdu, "intcol").unwrap();
 //! # }
 //! ```
 //!
@@ -413,7 +415,7 @@
 //! # let filename = "../testdata/full_example.fits";
 //! # let mut fptr = fitsio::FitsFile::open(filename).unwrap();
 //! # let hdu = fptr.hdu("TESTEXT").unwrap();
-//! for column in hdu.columns(&mut fptr) {
+//! for column in fptr.columns(&hdu) {
 //!     // Do something with column
 //! }
 //! # }
@@ -448,7 +450,7 @@
 //! # };
 //! # let hdu = fptr.create_image("".to_string(), &desc).unwrap();
 //! let data_to_write: Vec<f64> = vec![1.0, 2.0, 3.0];
-//! hdu.write_section(&mut fptr, 0, data_to_write.len(), &data_to_write).unwrap();
+//! fptr.write_section(&hdu, 0, data_to_write.len(), &data_to_write).unwrap();
 //! # }
 //! ```
 //!
@@ -473,7 +475,7 @@
 //! # let hdu = fptr.create_image("".to_string(), &desc).unwrap();
 //! let data_to_write: Vec<f64> = vec![1.0, 2.0, 3.0, 4.0];
 //! let ranges = [&(0..1), &(0..1)];
-//! hdu.write_region(&mut fptr, &ranges, &data_to_write).unwrap();
+//! fptr.write_region(&hdu, &ranges, &data_to_write).unwrap();
 //! # }
 //! ```
 //!
@@ -499,7 +501,7 @@
 //! # let filename = filename.to_str().unwrap();
 //! # let mut fptr = fitsio::FitsFile::edit(filename).unwrap();
 //! # let hdu = fptr.hdu(0).unwrap();
-//! hdu.resize(&mut fptr, &[1024, 1024]).unwrap();
+//! fptr.resize(hdu, &[1024, 1024]).unwrap();
 //! #
 //! // Have to get the HDU again, to reflect the latest changes
 //! let hdu = fptr.hdu(0).unwrap();
@@ -543,8 +545,8 @@
 //! # let hdu = fptr.create_table("foo".to_string(), &table_description)
 //! #     .unwrap();
 //! let data_to_write: Vec<i32> = vec![10101; 5];
-//! hdu.write_col(&mut fptr, "bar", &data_to_write).unwrap();
-//! let data: Vec<i32> = hdu.read_col(&mut fptr, "bar").unwrap();
+//! fptr.write_col(&hdu, "bar", &data_to_write).unwrap();
+//! let data: Vec<i32> = fptr.read_col(&hdu, "bar").unwrap();
 //! assert_eq!(data, vec![10101, 10101, 10101, 10101, 10101]);
 //! # }
 //! ```
@@ -572,8 +574,8 @@
 //! # let hdu = fptr.create_table("foo".to_string(), &table_description)
 //! #     .unwrap();
 //! let data_to_write: Vec<i32> = vec![10101; 10];
-//! hdu.write_col_range(&mut fptr, "bar", &data_to_write, &(0..4)).unwrap();
-//! let data: Vec<i32> = hdu.read_col(&mut fptr, "bar").unwrap();
+//! fptr.write_col_range(&hdu, "bar", &data_to_write, &(0..4)).unwrap();
+//! let data: Vec<i32> = fptr.read_col(&hdu, "bar").unwrap();
 //! assert_eq!(data, vec![10101, 10101, 10101, 10101, 10101]);
 //! # }
 //! ```
@@ -610,7 +612,7 @@
 //! let column_description = ColumnDescription::new("abcdefg")
 //! .with_type(ColumnDataType::Int)
 //! .create().unwrap();
-//! hdu.append_column(&mut fptr, &column_description).unwrap();
+//! fptr.append_column(&hdu, &column_description).unwrap();
 //! # }
 //!
 //! ```
@@ -641,7 +643,7 @@
 //! # ];
 //! # let hdu = fptr.create_table("foo".to_string(), table_description)
 //! #     .unwrap();
-//! let newhdu = hdu.delete_column(&mut fptr, "bar").unwrap();
+//! let newhdu = fptr.delete_column(&hdu, "bar").unwrap();
 //! # }
 //! # {
 //! # let tdir = tempdir::TempDir::new("fitsio-").unwrap();
@@ -657,7 +659,7 @@
 //! # let hdu = fptr.create_table("foo".to_string(), table_description)
 //! #     .unwrap();
 //! // or
-//! let newhdu = hdu.delete_column(&mut fptr, 0).unwrap();
+//! let newhdu = fptr.delete_column(&hdu, 0).unwrap();
 //! # }
 //! # }
 //! ```

--- a/fitsio/src/lib.rs
+++ b/fitsio/src/lib.rs
@@ -278,8 +278,8 @@
 //!
 //! ## General calling behaviour
 //!
-//! All subsequent data acess is performed through the [`FitsHdu`][fits-hdu] object. Most methods
-//! take the currently open [`FitsFile`][fits-file] as the first parameter.
+//! All subsequent data acess is performed through the [`FitsFile`][fits-file] object. Most methods
+//! take an [`FitsHdu`][fits-hdu] object as the first parameter.
 //!
 //! # Header keys
 //!


### PR DESCRIPTION
The current API attaches most methods on the `FitsHdu` object, which in turn takes the `FitsFile` object as it's first parameter (to actually perform the changes).

This PR proposes the other way around, where all methods are attached to the `FitsFile` object, and take the `FitsHdu` object as a parameter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mindriot101/rust-fitsio/49)
<!-- Reviewable:end -->
