### PR TITLE
Use C calling convention where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Addded
+
 ### Changed
+
+* (`fitsio`) _breaking change_: inverted the order of image/region axes to match the C row-major convention
+
 ### Removed
 
 ## [0.12.1] - 2018-02-23

--- a/fitsio-sys-bindgen/build.rs
+++ b/fitsio-sys-bindgen/build.rs
@@ -29,8 +29,7 @@ fn main() {
                     "{} was not found in the pkg-config search path",
                     package_name
                 ).as_ref(),
-            )
-            {
+            ) {
                 let err_msg = format!(
                     "
 Cannot find {} on the pkg-config search path.  Consider installing the library for your

--- a/fitsio-sys/build.rs
+++ b/fitsio-sys/build.rs
@@ -16,8 +16,7 @@ fn main() {
                     "{} was not found in the pkg-config search path",
                     package_name
                 ).as_ref(),
-            )
-            {
+            ) {
                 let err_msg = format!(
                     "
 Cannot find {} on the pkg-config search path.  Consider installing the library for your

--- a/fitsio-sys/src/lib.rs
+++ b/fitsio-sys/src/lib.rs
@@ -416,8 +416,7 @@ extern "C" {
         buffsize: *mut size_t,
         deltasize: size_t,
         mem_realloc: ::std::option::Option<
-            unsafe extern "C" fn(p: *mut c_void, newsize: size_t)
-                                 -> *mut c_void,
+            unsafe extern "C" fn(p: *mut c_void, newsize: size_t) -> *mut c_void,
         >,
         status: *mut c_int,
     ) -> c_int;
@@ -472,8 +471,7 @@ extern "C" {
         buffsize: *mut size_t,
         deltasize: size_t,
         mem_realloc: ::std::option::Option<
-            unsafe extern "C" fn(p: *mut c_void, newsize: size_t)
-                                 -> *mut c_void,
+            unsafe extern "C" fn(p: *mut c_void, newsize: size_t) -> *mut c_void,
         >,
         status: *mut c_int,
     ) -> c_int;
@@ -4045,14 +4043,15 @@ extern "C" {
         offset: c_long,
         nPerLoop: c_long,
         workFn: ::std::option::Option<
-            unsafe extern "C" fn(totaln: c_long,
-                                 offset: c_long,
-                                 firstn: c_long,
-                                 nvalues: c_long,
-                                 narrays: c_int,
-                                 data: *mut iteratorCol,
-                                 userPointer: *mut c_void)
-                                 -> c_int,
+            unsafe extern "C" fn(
+                totaln: c_long,
+                offset: c_long,
+                firstn: c_long,
+                nvalues: c_long,
+                narrays: c_int,
+                data: *mut iteratorCol,
+                userPointer: *mut c_void,
+            ) -> c_int,
         >,
         userPointer: *mut c_void,
         status: *mut c_int,

--- a/fitsio/src/columndescription.rs
+++ b/fitsio/src/columndescription.rs
@@ -67,9 +67,7 @@ impl ColumnDescription {
                 data_type: d.clone(),
             }),
             None => {
-                Err(
-                    "No data type given. Ensure the `with_type` method has been called.".into(),
-                )
+                Err("No data type given. Ensure the `with_type` method has been called.".into())
             }
         }
     }
@@ -91,11 +89,7 @@ pub struct ColumnDataDescription {
 impl ColumnDataDescription {
     /// Create a new column data description
     pub fn new(typ: ColumnDataType, repeat: usize, width: usize) -> Self {
-        ColumnDataDescription {
-            repeat,
-            width,
-            typ,
-        }
+        ColumnDataDescription { repeat, width, typ }
     }
 
     /// Shortcut for creating a scalar column
@@ -128,13 +122,11 @@ impl From<ColumnDataDescription> for String {
                     )
                 }
             }
-            _ => {
-                format!(
-                    "{repeat}{data_type}",
-                    data_type = String::from(orig.typ),
-                    repeat = orig.repeat
-                )
-            }
+            _ => format!(
+                "{repeat}{data_type}",
+                data_type = String::from(orig.typ),
+                repeat = orig.repeat
+            ),
         }
     }
 }
@@ -217,12 +209,10 @@ impl FromStr for ColumnDataDescription {
             'I' => ColumnDataType::Short,
             'K' => ColumnDataType::Long,
             'A' => ColumnDataType::String,
-            _ => {
-                panic!(
-                    "Have not implemented str -> ColumnDataType for {}",
-                    data_type_char
-                )
-            }
+            _ => panic!(
+                "Have not implemented str -> ColumnDataType for {}",
+                data_type_char
+            ),
         };
 
         Ok(ColumnDataDescription {

--- a/fitsio/src/columndescription.rs
+++ b/fitsio/src/columndescription.rs
@@ -92,9 +92,9 @@ impl ColumnDataDescription {
     /// Create a new column data description
     pub fn new(typ: ColumnDataType, repeat: usize, width: usize) -> Self {
         ColumnDataDescription {
-            repeat: repeat,
-            width: width,
-            typ: typ,
+            repeat,
+            width,
+            typ,
         }
     }
 
@@ -226,9 +226,9 @@ impl FromStr for ColumnDataDescription {
         };
 
         Ok(ColumnDataDescription {
-            repeat: repeat,
+            repeat,
             typ: data_type,
-            width: width,
+            width,
         })
     }
 }

--- a/fitsio/src/fitserror.rs
+++ b/fitsio/src/fitserror.rs
@@ -16,7 +16,7 @@ pub fn check_status(status: i32) -> Result<()> {
     match status {
         0 => Ok(()),
         _ => Err(Error::Fits(FitsError {
-            status: status,
+            status,
             message: status_to_string(status)?.expect("guaranteed to be Some"),
         })),
     }

--- a/fitsio/src/fitsfile.rs
+++ b/fitsio/src/fitsfile.rs
@@ -79,11 +79,9 @@ impl FitsFile {
             );
         }
 
-        check_status(status).map(|_| {
-            FitsFile {
-                fptr,
-                filename: filename.clone(),
-            }
+        check_status(status).map(|_| FitsFile {
+            fptr,
+            filename: filename.clone(),
         })
     }
 
@@ -103,11 +101,9 @@ impl FitsFile {
             );
         }
 
-        check_status(status).map(|_| {
-            FitsFile {
-                fptr,
-                filename: filename.clone(),
-            }
+        check_status(status).map(|_| FitsFile {
+            fptr,
+            filename: filename.clone(),
         })
     }
 
@@ -367,13 +363,11 @@ impl FitsFile {
         let mut status = 0;
 
         if status != 0 {
-            return Err(
-                FitsError {
-                    status,
-                    // unwrap guaranteed to succesed as status > 0
-                    message: status_to_string(status)?.unwrap(),
-                }.into(),
-            );
+            return Err(FitsError {
+                status,
+                // unwrap guaranteed to succesed as status > 0
+                message: status_to_string(status)?.unwrap(),
+            }.into());
         }
 
         unsafe {
@@ -387,13 +381,11 @@ impl FitsFile {
         }
 
         if status != 0 {
-            return Err(
-                FitsError {
-                    status,
-                    // unwrap guaranteed to succesed as status > 0
-                    message: status_to_string(status)?.unwrap(),
-                }.into(),
-            );
+            return Err(FitsError {
+                status,
+                // unwrap guaranteed to succesed as status > 0
+                message: status_to_string(status)?.unwrap(),
+            }.into());
         }
 
         // Current HDU should be at the new HDU
@@ -510,7 +502,6 @@ impl<'a> NewFitsFile<'a> {
         }
 
         check_status(status).and_then(|_| {
-
             let mut f = FitsFile {
                 fptr,
                 filename: path.clone(),
@@ -729,15 +720,16 @@ impl ReadsCol for String {
         range: &Range<usize>,
     ) -> Result<Vec<Self>> {
         match fits_file.fetch_hdu_info() {
-            Ok(HduInfo::TableInfo { column_descriptions, .. }) => {
+            Ok(HduInfo::TableInfo {
+                column_descriptions,
+                ..
+            }) => {
                 let num_output_rows = range.end - range.start + 1;
                 let test_name = name.into();
                 let column_number = column_descriptions
                     .iter()
                     .position(|desc| desc.name == test_name)
-                    .ok_or_else(|| {
-                        Error::Message(format!("Cannot find column {:?}", test_name))
-                    })?;
+                    .ok_or_else(|| Error::Message(format!("Cannot find column {:?}", test_name)))?;
 
                 /* Set up the storage arrays for the column string values */
                 let mut raw_char_data: Vec<*mut libc::c_char> =
@@ -821,9 +813,7 @@ pub trait WritesCol {
             }
             Ok(HduInfo::ImageInfo { .. }) => Err("Cannot write column data to FITS image".into()),
             Ok(HduInfo::AnyInfo { .. }) => {
-                Err(
-                    "Cannot determine HDU type, so cannot write column data".into(),
-                )
+                Err("Cannot determine HDU type, so cannot write column data".into())
             }
             Err(e) => Err(e),
         }
@@ -913,9 +903,7 @@ impl WritesCol for String {
             }
             Ok(HduInfo::ImageInfo { .. }) => Err("Cannot write column data to FITS image".into()),
             Ok(HduInfo::AnyInfo { .. }) => {
-                Err(
-                    "Cannot determine HDU type, so cannot write column data".into(),
-                )
+                Err("Cannot determine HDU type, so cannot write column data".into())
             }
             Err(e) => Err(e),
         }
@@ -1349,9 +1337,9 @@ impl<'a> ColumnIterator<'a> {
     fn new(fits_file: &'a FitsFile) -> Self {
         match fits_file.fetch_hdu_info() {
             Ok(HduInfo::TableInfo {
-                   column_descriptions,
-                   num_rows: _num_rows,
-               }) => ColumnIterator {
+                column_descriptions,
+                num_rows: _num_rows,
+            }) => ColumnIterator {
                 current: 0,
                 column_descriptions: column_descriptions,
                 fits_file: fits_file,
@@ -1375,56 +1363,36 @@ impl<'a> Iterator for ColumnIterator<'a> {
             let current_type = description.data_type.typ;
 
             let retval = match current_type {
-                ColumnDataType::Int => {
-                    i32::read_col(self.fits_file, current_name)
-                        .map(|data| {
-                            Column::Int32 {
-                                name: current_name.to_string(),
-                                data: data,
-                            }
-                        })
-                        .ok()
-                }
-                ColumnDataType::Long => {
-                    i64::read_col(self.fits_file, current_name)
-                        .map(|data| {
-                            Column::Int64 {
-                                name: current_name.to_string(),
-                                data: data,
-                            }
-                        })
-                        .ok()
-                }
-                ColumnDataType::Float => {
-                    f32::read_col(self.fits_file, current_name)
-                        .map(|data| {
-                            Column::Float {
-                                name: current_name.to_string(),
-                                data: data,
-                            }
-                        })
-                        .ok()
-                }
-                ColumnDataType::Double => {
-                    f64::read_col(self.fits_file, current_name)
-                        .map(|data| {
-                            Column::Double {
-                                name: current_name.to_string(),
-                                data: data,
-                            }
-                        })
-                        .ok()
-                }
-                ColumnDataType::String => {
-                    String::read_col(self.fits_file, current_name)
-                        .map(|data| {
-                            Column::String {
-                                name: current_name.to_string(),
-                                data: data,
-                            }
-                        })
-                        .ok()
-                }
+                ColumnDataType::Int => i32::read_col(self.fits_file, current_name)
+                    .map(|data| Column::Int32 {
+                        name: current_name.to_string(),
+                        data: data,
+                    })
+                    .ok(),
+                ColumnDataType::Long => i64::read_col(self.fits_file, current_name)
+                    .map(|data| Column::Int64 {
+                        name: current_name.to_string(),
+                        data: data,
+                    })
+                    .ok(),
+                ColumnDataType::Float => f32::read_col(self.fits_file, current_name)
+                    .map(|data| Column::Float {
+                        name: current_name.to_string(),
+                        data: data,
+                    })
+                    .ok(),
+                ColumnDataType::Double => f64::read_col(self.fits_file, current_name)
+                    .map(|data| Column::Double {
+                        name: current_name.to_string(),
+                        data: data,
+                    })
+                    .ok(),
+                ColumnDataType::String => String::read_col(self.fits_file, current_name)
+                    .map(|data| Column::String {
+                        name: current_name.to_string(),
+                        data: data,
+                    })
+                    .ok(),
                 _ => unimplemented!(),
             };
 
@@ -1460,9 +1428,8 @@ impl FitsHdu {
 
     /// Read the HDU name
     pub fn name(&self, fits_file: &mut FitsFile) -> Result<String> {
-        let extname = self.read_key(fits_file, "EXTNAME").unwrap_or_else(
-            |_| "".to_string(),
-        );
+        let extname = self.read_key(fits_file, "EXTNAME")
+            .unwrap_or_else(|_| "".to_string());
         Ok(extname)
     }
 
@@ -1659,7 +1626,10 @@ impl FitsHdu {
         /* We have to split up the fetching of the number of columns from the inserting of the
          * new column, as otherwise we're trying move out of self */
         let result = match self.info {
-            HduInfo::TableInfo { ref column_descriptions, .. } => Ok(column_descriptions.len()),
+            HduInfo::TableInfo {
+                ref column_descriptions,
+                ..
+            } => Ok(column_descriptions.len()),
             HduInfo::ImageInfo { .. } => Err("Cannot add columns to FITS image".into()),
             HduInfo::AnyInfo { .. } => {
                 Err("Cannot determine HDU type, so cannot add columns".into())
@@ -1767,9 +1737,9 @@ impl FitsHdu {
 
     /// Iterate over the columns in a fits file
     pub fn columns<'a>(&self, fits_file: &'a mut FitsFile) -> ColumnIterator<'a> {
-        fits_file.make_current(self).expect(
-            "Cannot make hdu current",
-        );
+        fits_file
+            .make_current(self)
+            .expect("Cannot make hdu current");
         ColumnIterator::new(fits_file)
     }
 
@@ -1971,9 +1941,9 @@ mod test {
         f.change_hdu(1).unwrap();
         match f.fetch_hdu_info() {
             Ok(HduInfo::TableInfo {
-                   column_descriptions,
-                   num_rows,
-               }) => {
+                column_descriptions,
+                num_rows,
+            }) => {
                 assert_eq!(num_rows, 50);
                 assert_eq!(
                     column_descriptions
@@ -2039,7 +2009,10 @@ mod test {
                 .map(|mut f| {
                     f.change_hdu("foo").unwrap();
                     match f.fetch_hdu_info() {
-                        Ok(HduInfo::TableInfo { column_descriptions, .. }) => {
+                        Ok(HduInfo::TableInfo {
+                            column_descriptions,
+                            ..
+                        }) => {
                             let column_names = column_descriptions
                                 .iter()
                                 .map(|desc| desc.name.clone())
@@ -2238,14 +2211,12 @@ mod test {
         }
 
         match hdu.read_key::<f64>(&mut f, "DBLTEST") {
-            Ok(value) => {
-                assert!(
-                    floats_close_f64(value, 0.09375),
-                    "{:?} != {:?}",
-                    value,
-                    0.09375
-                )
-            }
+            Ok(value) => assert!(
+                floats_close_f64(value, 0.09375),
+                "{:?} != {:?}",
+                value,
+                0.09375
+            ),
             Err(e) => panic!("Error reading key: {:?}", e),
         }
 
@@ -2367,15 +2338,13 @@ mod test {
         let mut f = FitsFile::open("../testdata/full_example.fits").unwrap();
         let hdu = f.hdu(1).unwrap();
         match hdu.read_col_range::<i32>(&mut f, "intcol", &(0..1024)) {
-            Err(e) => {
-                assert_eq!(
-                    e,
-                    Error::Index(IndexError {
-                        message: "given indices out of range".to_string(),
-                        given: (0..1024),
-                    })
-                )
-            }
+            Err(e) => assert_eq!(
+                e,
+                Error::Index(IndexError {
+                    message: "given indices out of range".to_string(),
+                    given: (0..1024),
+                })
+            ),
             _ => panic!("Should be error"),
         }
     }
@@ -2930,7 +2899,10 @@ mod test {
             let newhdu = hdu.insert_column(&mut f, 0, &coldesc).unwrap();
 
             match newhdu.info {
-                HduInfo::TableInfo { column_descriptions, .. } => {
+                HduInfo::TableInfo {
+                    column_descriptions,
+                    ..
+                } => {
                     assert_eq!(column_descriptions[0].name, "abcdefg");
                 }
                 _ => panic!("ERROR"),
@@ -2954,7 +2926,10 @@ mod test {
             let newhdu = hdu.append_column(&mut f, &coldesc).unwrap();
 
             match newhdu.info {
-                HduInfo::TableInfo { column_descriptions, .. } => {
+                HduInfo::TableInfo {
+                    column_descriptions,
+                    ..
+                } => {
                     assert_eq!(
                         column_descriptions[column_descriptions.len() - 1].name,
                         "abcdefg"
@@ -2973,11 +2948,12 @@ mod test {
             let newhdu = hdu.delete_column(&mut f, "intcol").unwrap();
 
             match newhdu.info {
-                HduInfo::TableInfo { column_descriptions, .. } => {
-                    for col in column_descriptions {
-                        assert!(col.name != "intcol");
-                    }
-                }
+                HduInfo::TableInfo {
+                    column_descriptions,
+                    ..
+                } => for col in column_descriptions {
+                    assert!(col.name != "intcol");
+                },
                 _ => panic!("ERROR"),
             }
         });
@@ -3006,11 +2982,12 @@ mod test {
             let newhdu = hdu.delete_column(&mut f, 0).unwrap();
 
             match newhdu.info {
-                HduInfo::TableInfo { column_descriptions, .. } => {
-                    for col in column_descriptions {
-                        assert!(col.name != "intcol");
-                    }
-                }
+                HduInfo::TableInfo {
+                    column_descriptions,
+                    ..
+                } => for col in column_descriptions {
+                    assert!(col.name != "intcol");
+                },
                 _ => panic!("ERROR"),
             }
         });

--- a/fitsio/src/fitsfile.rs
+++ b/fitsio/src/fitsfile.rs
@@ -2643,20 +2643,20 @@ mod test {
                 let mut f = FitsFile::create(filename).open().unwrap();
                 let image_description = ImageDescription {
                     data_type: ImageType::LONG_IMG,
-                    dimensions: &[100, 20],
+                    dimensions: &[100, 5],
                 };
                 let hdu = f.create_image("foo".to_string(), &image_description)
                     .unwrap();
 
-                let data: Vec<i64> = (0..121).map(|v| v + 50).collect();
-                hdu.write_region(&mut f, &[&(0..10), &(0..10)], &data)
+                let data: Vec<i64> = (0..66).map(|v| v + 50).collect();
+                hdu.write_region(&mut f, &[&(0..10), &(0..5)], &data)
                     .unwrap();
             }
 
             let mut f = FitsFile::open(filename).unwrap();
             let hdu = f.hdu("foo").unwrap();
-            let chunk: Vec<i64> = hdu.read_region(&mut f, &[&(0..10), &(0..10)]).unwrap();
-            assert_eq!(chunk.len(), 11 * 11);
+            let chunk: Vec<i64> = hdu.read_region(&mut f, &[&(0..10), &(0..5)]).unwrap();
+            assert_eq!(chunk.len(), 11 * 6);
             assert_eq!(chunk[0], 50);
             assert_eq!(chunk[25], 75);
         });

--- a/fitsio/src/fitsfile.rs
+++ b/fitsio/src/fitsfile.rs
@@ -40,6 +40,9 @@ pub struct ImageDescription<'a> {
     pub data_type: ImageType,
 
     /// Shape of the image
+    ///
+    /// Unlike cfitsio, the order of the dimensions follows the C convention, i.e. [row-major
+    /// order](https://en.wikipedia.org/wiki/Row-_and_column-major_order).
     pub dimensions: &'a [usize],
 }
 

--- a/fitsio/src/fitsfile.rs
+++ b/fitsio/src/fitsfile.rs
@@ -81,7 +81,7 @@ impl FitsFile {
 
         check_status(status).map(|_| {
             FitsFile {
-                fptr: fptr,
+                fptr,
                 filename: filename.clone(),
             }
         })
@@ -105,7 +105,7 @@ impl FitsFile {
 
         check_status(status).map(|_| {
             FitsFile {
-                fptr: fptr,
+                fptr,
                 filename: filename.clone(),
             }
         })
@@ -252,7 +252,7 @@ impl FitsFile {
 
                 HduInfo::ImageInfo {
                     shape: shape.iter().map(|v| *v as usize).collect(),
-                    image_type: image_type,
+                    image_type,
                 }
             }
             1 | 2 => {
@@ -294,7 +294,7 @@ impl FitsFile {
                 }
 
                 HduInfo::TableInfo {
-                    column_descriptions: column_descriptions,
+                    column_descriptions,
                     num_rows: num_rows as usize,
                 }
             }
@@ -369,7 +369,7 @@ impl FitsFile {
         if status != 0 {
             return Err(
                 FitsError {
-                    status: status,
+                    status,
                     // unwrap guaranteed to succesed as status > 0
                     message: status_to_string(status)?.unwrap(),
                 }.into(),
@@ -389,7 +389,7 @@ impl FitsFile {
         if status != 0 {
             return Err(
                 FitsError {
-                    status: status,
+                    status,
                     // unwrap guaranteed to succesed as status > 0
                     message: status_to_string(status)?.unwrap(),
                 }.into(),
@@ -512,7 +512,7 @@ impl<'a> NewFitsFile<'a> {
         check_status(status).and_then(|_| {
 
             let mut f = FitsFile {
-                fptr: fptr,
+                fptr,
                 filename: path.clone(),
             };
 

--- a/fitsio/src/lib.rs
+++ b/fitsio/src/lib.rs
@@ -771,7 +771,7 @@
 //! [new-fits-file-open]: fitsfile/struct.NewFitsFile.html#method.open
 //! [new-fits-file-with-custom-primary]: fitsfile/struct.NewFitsFile.html#method.with_custom_primary
 
-#![warn(missing_docs)]
+#![deny(missing_docs)]
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 

--- a/fitsio/src/lib.rs
+++ b/fitsio/src/lib.rs
@@ -176,6 +176,9 @@
 //! # }
 //! ```
 //!
+//! _Unlike cfitsio, the order of the dimensions of `new_size follows the C convention, i.e.
+//! [row-major order](https://en.wikipedia.org/wiki/Row-_and_column-major_order)._
+//!
 //! ## Creating a new table
 //!
 //! Similar to creating new images, new tables are created with the


### PR DESCRIPTION
An example given on the [rust users forum](https://users.rust-lang.org/t/calling-all-rusty-astronomers/14099/10?u=srwalker101) shows that when defining the dimensions of new images, the array is treated in fortran order rather than C. See the [cfitsio documentation](https://heasarc.gsfc.nasa.gov/fitsio/c/c_user/node40.html):

> C programmers should note that the ordering of arrays in FITS files, and hence in all the CFITSIO calls, is more similar to the dimensionality of arrays in Fortran rather than C. For instance if a FITS image has NAXIS1 = 100 and NAXIS2 = 50, then a 2-D array just large enough to hold the image should be declared as array[50][100] and not as array[100][50].

Consider where else this may be the case, and fix them.

- [x] creating new images
- [x] describing image regions
- [x] resizing images
- [x] reading image shape

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mindriot101/rust-fitsio/59)
<!-- Reviewable:end -->
