### PR TITLE
Readimage not implemented for ndarray

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -28,3 +28,6 @@ run_cargo run --manifest-path fitsio/Cargo.toml --example full_example
 
 # Test the array feature
 run_cargo test --manifest-path fitsio/Cargo.toml --features array
+
+# Compile the book examples
+run_cargo build --manifest-path homepage/fitsioexample/Cargo.toml --bins

--- a/fitsio/Cargo.toml
+++ b/fitsio/Cargo.toml
@@ -18,7 +18,7 @@ libc = "0"
 fitsio-sys = { version = "0", path = "../fitsio-sys", optional = true}
 fitsio-sys-bindgen = { version = "0", path = "../fitsio-sys-bindgen", optional = true }
 clippy = { version = "0", optional = true }
-ndarray = { version = "0.11.2", optional = true }
+ndarray = { version = "0", optional = true }
 
 [dev-dependencies]
 tempdir = "0.3.4"

--- a/homepage/fitsioexample/Cargo.toml
+++ b/homepage/fitsioexample/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 authors = ["Simon Walker <s.r.walker101@googlemail.com>"]
 
 [dependencies]
-fitsio = { version = "*", git = "https://github.com/mindriot101/rust-fitsio", features = ["array"]}
+fitsio = { version = "*", path = "../../fitsio", features = ["array"]}
 ndarray = "*"

--- a/homepage/fitsioexample/src/bin/ndarray_support.rs
+++ b/homepage/fitsioexample/src/bin/ndarray_support.rs
@@ -1,19 +1,21 @@
 extern crate fitsio;
 extern crate ndarray;
 
-use std::error::Error;
 use fitsio::FitsFile;
 use ndarray::ArrayD;
+use std::error::Error;
 
 fn try_main() -> Result<(), Box<Error>> {
-let filename = "../testdata/full_example.fits";
-let mut fptr = FitsFile::open(filename)?;
-let phdu = fptr.primary_hdu()?;
-let image: ArrayD<f32> = phdu.read_image(&mut fptr)?;
-let new_image = (image * 4.0) / 5.2;
-assert_eq!(new_image.ndim(), 2);
+    let filename = "../testdata/full_example.fits";
+    let mut fptr = FitsFile::open(filename)?;
+    let phdu = fptr.primary_hdu()?;
+    let image: ArrayD<f32> = phdu.read_image(&mut fptr)?;
+    let new_image = (image * 4.0) / 5.2;
+    assert_eq!(new_image.ndim(), 2);
 
-Ok(())
+    Ok(())
 }
 
-fn main() { try_main().unwrap() }
+fn main() {
+    try_main().unwrap()
+}


### PR DESCRIPTION
@Findus32 showed compilation problems with the homepage example. See https://github.com/mindriot101/rust-fitsio/issues/102

The problem was caused by different versions of `ndarray`. `fitsio` specified 0.11.2, and implemented `ReadImage` for the 0.11.2 version of `ArrayD`, whereas the example did not specify the version of `ndarray` (i.e. `ndarray = "*"`). When @Findus32 did a fresh clone of the repo, it installed the latest version of `ndarray` i.e. 0.12.1.

It seems that implementing a trait for a different version of a struct (i.e. `ArrayD` version 0.11.2 vs `ArrayD` version 0.12.1) does not propagate to the newer version.

This might be quite annoying, if the version of `ndarray` is different between library code and user code.
