### PR TITLE
Implement fitsfile fptr via ptr::NonNull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Changed
 ### Removed
 
+## [0.15.0]
+
+### Added
+
+### Changed
+
+* (`fitsio`) **BREAKING CHANGE**: implementing underlying raw `fitsfile` pointer as a `std::ptr::NonNull`, meaning the pointer is guaranteed to never be null, increasing the safety of the API. The breaking change is that more methods require a mutable (exclusive) reference (due to the method of converting the `NonNull` to mutable pointer, required by some lower level methods). The upside is that the `FitsFile` object *should* have exclusive access as it wraps the state of the fits file on disk. Safe concurrent (though not parallel) access is given by the `threadsafe` method.
+
+### Removed
+
+
 ## [0.14.1]
 
 ### Added
@@ -157,6 +168,7 @@ Nothing
 [0.13.0]: https://github.com/mindriot101/rust-fitsio/compare/v0.12.1...v0.13.0
 [0.14.0]: https://github.com/mindriot101/rust-fitsio/compare/v0.13.0...v0.14.0
 [0.14.1]: https://github.com/mindriot101/rust-fitsio/compare/v0.14.0...v0.14.1
+[0.15.0]: https://github.com/mindriot101/rust-fitsio/compare/v0.14.1...v0.15.0
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Or pin a specific version:
 
 ```toml
 [dependencies]
-fitsio = "0.14.1"
+fitsio = "0.15.0"
 ```
 
 This repository contains `fitsio-sys-bindgen` which generates the C
@@ -58,7 +58,7 @@ or use from your `Cargo.toml` as such:
 
 ```toml
 [dependencies]
-fitsio = { version = "0.14.1", default-features = false, features = ["bindgen"] }
+fitsio = { version = "0.15.0", default-features = false, features = ["bindgen"] }
 ```
 
 

--- a/fitsio/Cargo.toml
+++ b/fitsio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fitsio"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Simon Walker <s.r.walker101@googlemail.com>"]
 description = "Rust implmentation of astronomy fits file handling"
 homepage = "https://github.com/mindriot101/rust-fitsio"

--- a/fitsio/src/hdu.rs
+++ b/fitsio/src/hdu.rs
@@ -427,7 +427,7 @@ impl FitsHdu {
                 let mut status = 0;
                 unsafe {
                     fits_resize_img(
-                        fits_file.fptr as *mut _,
+                        fits_file.fptr.as_mut() as *mut _,
                         image_type.into(),
                         new_size.len() as _,
                         new_size.as_ptr() as *mut _,
@@ -473,8 +473,8 @@ impl FitsHdu {
         let mut status = 0;
         unsafe {
             fits_copy_hdu(
-                src_fits_file.fptr as *mut _,
-                dest_fits_file.fptr as *mut _,
+                src_fits_file.fptr.as_mut() as *mut _,
+                dest_fits_file.fptr.as_mut() as *mut _,
                 0,
                 &mut status,
             );
@@ -532,7 +532,7 @@ impl FitsHdu {
 
         unsafe {
             fits_insert_col(
-                fits_file.fptr as *mut _,
+                fits_file.fptr.as_mut() as *mut _,
                 (position + 1) as _,
                 c_name.into_raw(),
                 c_type.into_raw(),
@@ -658,7 +658,11 @@ impl FitsHdu {
         let mut status = 0;
 
         unsafe {
-            fits_delete_col(fits_file.fptr as *mut _, (colno + 1) as _, &mut status);
+            fits_delete_col(
+                fits_file.fptr.as_mut() as *mut _,
+                (colno + 1) as _,
+                &mut status,
+            );
         }
 
         check_status(status).and_then(|_| fits_file.current_hdu())
@@ -686,7 +690,7 @@ impl FitsHdu {
 
         unsafe {
             fits_get_colnum(
-                fits_file.fptr as *mut _,
+                fits_file.fptr.as_mut() as *mut _,
                 CaseSensitivity::CASEINSEN as _,
                 c_col_name.as_ptr() as *mut _,
                 &mut colno,
@@ -934,7 +938,7 @@ impl FitsHdu {
         let mut status = 0;
         let mut curhdu = 0;
         unsafe {
-            fits_delete_hdu(fits_file.fptr as *mut _, &mut curhdu, &mut status);
+            fits_delete_hdu(fits_file.fptr.as_mut() as *mut _, &mut curhdu, &mut status);
         }
         check_status(status).map(|_| ())
     }
@@ -1052,7 +1056,7 @@ impl DescribesHdu for usize {
         let mut status = 0;
         unsafe {
             fits_movabs_hdu(
-                f.fptr as *mut _,
+                f.fptr.as_mut() as *mut _,
                 (*self + 1) as i32,
                 &mut hdu_type,
                 &mut status,
@@ -1070,7 +1074,7 @@ impl<'a> DescribesHdu for &'a str {
 
         unsafe {
             fits_movnam_hdu(
-                f.fptr as *mut _,
+                f.fptr.as_mut() as *mut _,
                 HduInfo::AnyInfo.into(),
                 c_hdu_name.into_raw(),
                 0,
@@ -1195,5 +1199,4 @@ mod tests {
             assert_eq!(counter, 2);
         });
     }
-
 }

--- a/fitsio/src/images.rs
+++ b/fitsio/src/images.rs
@@ -104,7 +104,7 @@ macro_rules! read_image_impl_vec {
 
                         unsafe {
                             fits_read_img(
-                                fits_file.fptr as *mut _,
+                                fits_file.fptr.as_mut() as *mut _,
                                 $data_type.into(),
                                 (range.start + 1) as i64,
                                 nelements as i64,
@@ -183,15 +183,15 @@ macro_rules! read_image_impl_vec {
 
                         unsafe {
                             fits_read_subset(
-                                fits_file.fptr as *mut _,   // fptr
-                                $data_type.into(),          // datatype
-                                fpixel.as_mut_ptr(),        // fpixel
-                                lpixel.as_mut_ptr(),        // lpixel
-                                inc.as_mut_ptr(),           // inc
-                                ptr::null_mut(),            // nulval
-                                out.as_mut_ptr() as *mut _, // array
-                                ptr::null_mut(),            // anynul
-                                &mut status,                // status
+                                fits_file.fptr.as_mut() as *mut _, // fptr
+                                $data_type.into(),                 // datatype
+                                fpixel.as_mut_ptr(),               // fpixel
+                                lpixel.as_mut_ptr(),               // lpixel
+                                inc.as_mut_ptr(),                  // inc
+                                ptr::null_mut(),                   // nulval
+                                out.as_mut_ptr() as *mut _,        // array
+                                ptr::null_mut(),                   // anynul
+                                &mut status,                       // status
                             );
                         }
 
@@ -223,7 +223,7 @@ macro_rules! write_image_impl {
                         let mut status = 0;
                         unsafe {
                             fits_write_img(
-                                fits_file.fptr as *mut _,
+                                fits_file.fptr.as_mut() as *mut _,
                                 $data_type.into(),
                                 (range.start + 1) as i64,
                                 nelements as i64,
@@ -266,7 +266,7 @@ macro_rules! write_image_impl {
 
                         unsafe {
                             fits_write_subset(
-                                fits_file.fptr as *mut _,
+                                fits_file.fptr.as_mut() as *mut _,
                                 $data_type.into(),
                                 fpixel.as_mut_ptr(),
                                 lpixel.as_mut_ptr(),
@@ -578,5 +578,4 @@ mod tests {
             }
         });
     }
-
 }

--- a/fitsio/src/lib.rs
+++ b/fitsio/src/lib.rs
@@ -926,9 +926,9 @@ extern crate fitsio_sys;
 
 use fitsio::FitsFile;
 
-# fn try_main() -> Result<(), Box<std::error::Error>> {
+# fn try_main() -> Result<(), Box<dyn std::error::Error>> {
 # let filename = "../testdata/full_example.fits";
-let fptr = FitsFile::open(filename)?;
+let mut fptr = FitsFile::open(filename)?;
 
 /* Find out the number of HDUs in the file */
 let mut num_hdus = 0;

--- a/fitsio/src/lib.rs
+++ b/fitsio/src/lib.rs
@@ -1044,7 +1044,7 @@ let _hdu = t.hdu(hdu_num).unwrap();
 [threadsafe-fits-file]: threadsafe_fitsfile/struct.ThreadsafeFitsFile.html
 */
 
-#![doc(html_root_url = "https://docs.rs/fitsio/0.14.1")]
+#![doc(html_root_url = "https://docs.rs/fitsio/0.15.0")]
 #![deny(missing_docs)]
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]


### PR DESCRIPTION
This means the `fptr` pointer can never be null, which is a good
guarantee to have. On the other hand, we have to make all of the member
methods take `self` mutably (i.e. exclusive access).

I think this is probably a reasonable tradeoff as the fitsfile pointer
should be owned exclusively. Two concurrent alterations to the same
backed file should not happen.