### PR TITLE
Use Rust 2018

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,6 @@ let f = fitsio::FitsFile::open("test.fits");
 Accessing the underlying `fitsfile` object
 
 ```rust
-extern crate fitsio;
-extern crate fitsio_sys;
-
 fn main() {
     let filename = "../testdata/full_example.fits";
     let fptr = fitsio::FitsFile::open(filename).unwrap();

--- a/fitsio-derive/Cargo.toml
+++ b/fitsio-derive/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "fitsio-derive"
+edition = "2018"
 version = "0.1.0"
 authors = ["Simon Walker <s.r.walker101@googlemail.com>"]
 description = "Custom derive macros for the fitsio crate"

--- a/fitsio-derive/src/lib.rs
+++ b/fitsio-derive/src/lib.rs
@@ -1,8 +1,3 @@
-extern crate proc_macro;
-#[macro_use]
-extern crate quote;
-extern crate syn;
-
 use proc_macro::TokenStream;
 use syn::DeriveInput;
 
@@ -20,7 +15,7 @@ pub fn read_row(input: TokenStream) -> TokenStream {
                     let ident = &field.ident.as_ref().unwrap();
                     let ident_str = ident.to_string();
                     if field.attrs.is_empty() {
-                        let src = quote! {
+                        let src = quote::quote! {
                             out.#ident = tbl.read_cell_value(fits_file, #ident_str, idx)?;
                         };
                         tokens.push(src);
@@ -39,7 +34,7 @@ pub fn read_row(input: TokenStream) -> TokenStream {
 
                                                 match lit {
                                                     syn::Lit::Str(ls) => {
-                                                        tokens.push(quote! {
+                                                        tokens.push(quote::quote! {
                                                             out.#ident = tbl.read_cell_value(
                                                                 fits_file,
                                                                 #ls,
@@ -68,7 +63,7 @@ pub fn read_row(input: TokenStream) -> TokenStream {
         _ => panic!("derive only possible for structs"),
     }
 
-    let expanded = quote! {
+    let expanded = quote::quote! {
         impl FitsRow for #name {
             fn from_table(
                 tbl: &::fitsio::hdu::FitsHdu,

--- a/fitsio-sys-bindgen/Cargo.toml
+++ b/fitsio-sys-bindgen/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "fitsio-sys-bindgen"
+edition = "2018"
 version = "0.0.2"
 authors = ["Simon Walker <s.r.walker101@googlemail.com>"]
 description = "FFI wrapper around cfitsio"

--- a/fitsio-sys-bindgen/build.rs
+++ b/fitsio-sys-bindgen/build.rs
@@ -1,6 +1,3 @@
-extern crate bindgen;
-extern crate pkg_config;
-
 use bindgen::RustTarget;
 use pkg_config::Error;
 use std::env;

--- a/fitsio-sys-bindgen/src/lib.rs
+++ b/fitsio-sys-bindgen/src/lib.rs
@@ -17,30 +17,30 @@
 //! ## Examples
 //!
 //! ```rust
-//! # extern crate fitsio_sys_bindgen as fitsio_sys;
 //! use std::ptr;
 //! use std::ffi;
-//! # use fitsio_sys::{ffinit, ffphps, ffclos};
+//! # use fitsio_sys_bindgen as fitsio_sys;
 //!
-//! # fn main() {
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let filename = ffi::CString::new("!/tmp/test.fits").unwrap();
 //! let mut fptr = ptr::null_mut();
 //! let mut status = 0;
 //!
 //! unsafe {
 //!     // Create a new file, clobbering any pre-existing file
-//!     ffinit(&mut fptr as *mut *mut _,
+//!     fitsio_sys::ffinit(&mut fptr as *mut *mut _,
 //!         filename.as_ptr(),
 //!         &mut status);
 //!
 //!     // Add an empty primary HDU
-//!     ffphps(fptr, 8, 0, ptr::null_mut(), &mut status);
+//!     fitsio_sys::ffphps(fptr, 8, 0, ptr::null_mut(), &mut status);
 //!
 //!     // Finally close the file
-//!     ffclos(fptr, &mut status);
+//!     fitsio_sys::ffclos(fptr, &mut status);
 //! }
 //!
 //! assert_eq!(status, 0);
+//! # Ok(())
 //! # }
 //! ```
 //!
@@ -65,14 +65,11 @@
     clippy::too_many_arguments,
     clippy::should_implement_trait
 )]
-extern crate libc;
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 #[cfg(test)]
 mod test {
-    extern crate tempdir;
-
     use super::*;
     use libc::c_char;
     use std::ffi;

--- a/fitsio-sys/Cargo.toml
+++ b/fitsio-sys/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "fitsio-sys"
 version = "0.3.0"
+edition = "2018"
 authors = ["Simon Walker <s.r.walker101@googlemail.com>"]
 description = "FFI wrapper around cfitsio"
 homepage = "https://github.com/mindriot101/rust-fitsio"

--- a/fitsio-sys/build.rs
+++ b/fitsio-sys/build.rs
@@ -1,5 +1,3 @@
-extern crate pkg_config;
-
 use pkg_config::Error;
 use std::io::Write;
 

--- a/fitsio-sys/src/lib.rs
+++ b/fitsio-sys/src/lib.rs
@@ -17,12 +17,11 @@
 //! ## Examples
 //!
 //! ```rust
-//! # extern crate fitsio_sys;
 //! use std::ptr;
 //! use std::ffi;
 //! # use fitsio_sys::{ffinit, ffphps, ffclos};
 //!
-//! # fn main() {
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let filename = ffi::CString::new("!/tmp/test.fits").unwrap();
 //! let mut fptr = ptr::null_mut();
 //! let mut status = 0;
@@ -41,6 +40,7 @@
 //! }
 //!
 //! assert_eq!(status, 0);
+//! # Ok(())
 //! # }
 //! ```
 //!

--- a/fitsio/Cargo.toml
+++ b/fitsio/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "fitsio"
 version = "0.15.0"
+edition = "2018"
 authors = ["Simon Walker <s.r.walker101@googlemail.com>"]
 description = "Rust implmentation of astronomy fits file handling"
 homepage = "https://github.com/mindriot101/rust-fitsio"

--- a/fitsio/benches/benchmarks.rs
+++ b/fitsio/benches/benchmarks.rs
@@ -1,14 +1,8 @@
-#[macro_use]
-extern crate criterion;
-#[macro_use]
-extern crate fitsio_derive;
-extern crate fitsio;
-extern crate tempdir;
-
 use criterion::Criterion;
 use fitsio::images::{ImageDescription, ImageType};
 use fitsio::tables::{ColumnDataType, ColumnDescription, FitsRow};
 use fitsio::FitsFile;
+use fitsio_derive::FitsRow;
 use tempdir::TempDir;
 
 fn opening_files(c: &mut Criterion) {
@@ -165,5 +159,5 @@ fn full_example(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, opening_files, full_example);
-criterion_main!(benches);
+criterion::criterion_group!(benches, opening_files, full_example);
+criterion::criterion_main!(benches);

--- a/fitsio/examples/full_example.rs
+++ b/fitsio/examples/full_example.rs
@@ -1,8 +1,3 @@
-extern crate fitsio;
-#[macro_use]
-extern crate fitsio_derive;
-extern crate tempdir;
-
 /* This example docuents the following things:
  *
  * creating a new file
@@ -22,6 +17,7 @@ use tempdir::TempDir;
 use fitsio::images::{ImageDescription, ImageType};
 use fitsio::tables::{ColumnDataType, ColumnDescription, FitsRow};
 use fitsio::FitsFile;
+use fitsio_derive::FitsRow;
 
 fn run() -> Result<(), Box<dyn Error>> {
     /* Create a temporary directory to work from */

--- a/fitsio/src/bin/fitssummary.rs
+++ b/fitsio/src/bin/fitssummary.rs
@@ -1,5 +1,3 @@
-extern crate fitsio;
-
 use std::env;
 use std::process;
 

--- a/fitsio/src/errors.rs
+++ b/fitsio/src/errors.rs
@@ -11,7 +11,7 @@ use std::ops::Range;
 use std::str::Utf8Error;
 use std::string::FromUtf8Error;
 use std::sync;
-use stringutils::status_to_string;
+use crate::stringutils::status_to_string;
 
 /// Enumeration of all error types
 #[derive(Debug)]
@@ -115,7 +115,7 @@ impl ::std::convert::From<IntoStringError> for Error {
     }
 }
 
-use fitsfile::FitsFile;
+use crate::fitsfile::FitsFile;
 type PoisonError<'a> = sync::PoisonError<sync::MutexGuard<'a, FitsFile>>;
 
 impl<'a> ::std::convert::From<PoisonError<'a>> for Error {

--- a/fitsio/src/fitsfile.rs
+++ b/fitsio/src/fitsfile.rs
@@ -8,20 +8,13 @@
  * similar architectures).
  */
 
-// If we are using the `bindgen` feature then import `fitsio_sys_bindgen` with a new name
-#[cfg(feature = "default")]
-use fitsio_sys;
-#[cfg(feature = "bindgen")]
-use fitsio_sys_bindgen as fitsio_sys;
-
-use self::fitsio_sys::fitsfile;
 use crate::errors::{check_status, Error, Result};
 use crate::hdu::{DescribesHdu, FitsHdu, FitsHduIterator, HduInfo};
 use crate::images::{ImageDescription, ImageType};
 use crate::longnam::*;
 use crate::stringutils::{self, status_to_string};
+use crate::sys::fitsfile;
 use crate::tables::{ColumnDataDescription, ConcreteColumnDescription};
-use libc;
 use std::ffi;
 use std::io::{self, Write};
 use std::path::Path;
@@ -1521,7 +1514,7 @@ mod test {
 
     #[test]
     fn test_access_fptr_unsafe() {
-        use crate::fitsio_sys::fitsfile;
+        use crate::sys::fitsfile;
 
         let mut f = FitsFile::open("../testdata/full_example.fits").unwrap();
         let fptr: *const fitsfile = unsafe { f.as_raw() };

--- a/fitsio/src/fitsfile.rs
+++ b/fitsio/src/fitsfile.rs
@@ -8,18 +8,24 @@
  * similar architectures).
  */
 
+// If we are using the `bindgen` feature then import `fitsio_sys_bindgen` with a new name
+#[cfg(feature = "default")]
+use fitsio_sys;
+#[cfg(feature = "bindgen")]
+use fitsio_sys_bindgen as fitsio_sys;
+
+use self::fitsio_sys::fitsfile;
 use crate::errors::{check_status, Error, Result};
-use fitsio_sys::fitsfile;
 use crate::hdu::{DescribesHdu, FitsHdu, FitsHduIterator, HduInfo};
 use crate::images::{ImageDescription, ImageType};
-use libc;
 use crate::longnam::*;
+use crate::stringutils::{self, status_to_string};
+use crate::tables::{ColumnDataDescription, ConcreteColumnDescription};
+use libc;
 use std::ffi;
 use std::io::{self, Write};
 use std::path::Path;
 use std::ptr;
-use crate::stringutils::{self, status_to_string};
-use crate::tables::{ColumnDataDescription, ConcreteColumnDescription};
 
 /// Main entry point to the FITS file format
 pub struct FitsFile {
@@ -128,8 +134,6 @@ impl FitsFile {
     # Example
 
     ```rust
-    # extern crate tempdir;
-    # extern crate fitsio;
     # fn main() -> Result<(), Box<std::error::Error>> {
     # let tdir = tempdir::TempDir::new("fitsio-").unwrap();
     # let tdir_path = tdir.path();
@@ -207,11 +211,10 @@ impl FitsFile {
     # Example
 
     ```rust
-    # extern crate fitsio;
     # #[cfg(feature = "default")]
-    # extern crate fitsio_sys as sys;
+    # use fitsio_sys as sys;
     # #[cfg(feature = "bindgen")]
-    # extern crate fitsio_sys_bindgen as sys;
+    # use fitsio_sys_bindgen as sys;
     # use fitsio::FitsFile;
     use fitsio::hdu::HduInfo;
     #
@@ -247,11 +250,10 @@ impl FitsFile {
     # Example
 
     ```rust
-    # extern crate fitsio;
     # #[cfg(feature = "default")]
-    # extern crate fitsio_sys as sys;
+    # use fitsio_sys as sys;
     # #[cfg(feature = "bindgen")]
-    # extern crate fitsio_sys_bindgen as sys;
+    # use fitsio_sys_bindgen as sys;
     # use fitsio::FitsFile;
     # use fitsio::hdu::HduInfo;
     #
@@ -424,8 +426,6 @@ impl FitsFile {
     # Example
 
     ```rust
-    # extern crate tempdir;
-    # extern crate fitsio;
     use fitsio::tables::{ColumnDataType, ColumnDescription};
 
     # fn main() -> Result<(), Box<std::error::Error>> {
@@ -507,8 +507,6 @@ impl FitsFile {
     # Example
 
     ```rust
-    # extern crate tempdir;
-    # extern crate fitsio;
     use fitsio::images::{ImageDescription, ImageType};
 
     # fn main() -> Result<(), Box<std::error::Error>> {
@@ -584,7 +582,6 @@ impl FitsFile {
     # Example
 
     ```rust
-    # extern crate fitsio;
     # fn main() -> Result<(), Box<std::error::Error>> {
     #     let mut fptr = fitsio::FitsFile::open("../testdata/full_example.fits")?;
     for hdu in fptr.iter() {
@@ -726,11 +723,10 @@ impl FitsFile {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate fitsio;
     /// # #[cfg(not(feature="bindgen"))]
-    /// extern crate fitsio_sys;
+    /// use fitsio_sys;
     /// # #[cfg(feature="bindgen")]
-    /// # extern crate fitsio_sys_bindgen as fitsio_sys;
+    /// # use fitsio_sys_bindgen as fitsio_sys;
     ///
     /// use fitsio::FitsFile;
     ///
@@ -789,9 +785,6 @@ custom primary HDU.
 # Example
 
 ```rust
-# extern crate tempdir;
-# extern crate fitsio;
-# fn main() {
 # let tdir = tempdir::TempDir::new("fitsio-").unwrap();
 # let tdir_path = tdir.path();
 # let _filename = tdir_path.join("test.fits");
@@ -808,7 +801,6 @@ let fptr = FitsFile::create(filename)
     .with_custom_primary(&description)
     .open()
     .unwrap();
-# }
 ```
 
 The [`open`][new-fits-file-open] method actually creates a `Result<FitsFile>` from this
@@ -817,9 +809,6 @@ temporary representation.
 # Example
 
 ```rust
-# extern crate tempdir;
-# extern crate fitsio;
-# fn main() {
 # let tdir = tempdir::TempDir::new("fitsio-").unwrap();
 # let tdir_path = tdir.path();
 # let _filename = tdir_path.join("test.fits");
@@ -828,7 +817,6 @@ use fitsio::FitsFile;
 
 // let filename = ...;
 let fptr = FitsFile::create(filename).open().unwrap();
-# }
 ```
 [new-fits-file]: struct.NewFitsFile.html
 [new-fits-file-open]: struct.NewFitsFile.html#method.open
@@ -903,8 +891,6 @@ where
     # Example
 
     ```rust
-    # extern crate tempdir;
-    # extern crate fitsio;
     # fn main() -> Result<(), Box<dyn std::error::Error>> {
     # let tdir = tempdir::TempDir::new("fitsio-")?;
     # let tdir_path = tdir.path();
@@ -946,8 +932,6 @@ where
     # Example
 
     ```rust
-    # extern crate tempdir;
-    # extern crate fitsio;
     # fn main() -> Result<(), Box<std::error::Error>> {
     # let tdir = tempdir::TempDir::new("fitsio-")?;
     # let tdir_path = tdir.path();
@@ -1031,21 +1015,14 @@ casesensitivity_into_impl!(i64);
 
 #[cfg(test)]
 mod test {
-    #[cfg(feature = "default")]
-    extern crate fitsio_sys as sys;
-    #[cfg(feature = "bindgen")]
-    extern crate fitsio_sys_bindgen as sys;
-
-    extern crate tempdir;
-
     use crate::errors::Error;
     use crate::fitsfile::FitsFile;
     use crate::fitsfile::{FileOpenMode, ImageDescription};
     use crate::hdu::{FitsHdu, HduInfo};
     use crate::images::ImageType;
-    use std::path::Path;
     use crate::tables::{ColumnDataType, ColumnDescription};
     use crate::testhelpers::{duplicate_test_file, with_temp_file};
+    use std::path::Path;
 
     #[test]
     fn test_opening_an_existing_file() {
@@ -1544,7 +1521,7 @@ mod test {
 
     #[test]
     fn test_access_fptr_unsafe() {
-        use fitsio_sys::fitsfile;
+        use crate::fitsio_sys::fitsfile;
 
         let mut f = FitsFile::open("../testdata/full_example.fits").unwrap();
         let fptr: *const fitsfile = unsafe { f.as_raw() };

--- a/fitsio/src/fitsfile.rs
+++ b/fitsio/src/fitsfile.rs
@@ -8,18 +8,18 @@
  * similar architectures).
  */
 
-use errors::{check_status, Error, Result};
+use crate::errors::{check_status, Error, Result};
 use fitsio_sys::fitsfile;
-use hdu::{DescribesHdu, FitsHdu, FitsHduIterator, HduInfo};
-use images::{ImageDescription, ImageType};
+use crate::hdu::{DescribesHdu, FitsHdu, FitsHduIterator, HduInfo};
+use crate::images::{ImageDescription, ImageType};
 use libc;
-use longnam::*;
+use crate::longnam::*;
 use std::ffi;
 use std::io::{self, Write};
 use std::path::Path;
 use std::ptr;
-use stringutils::{self, status_to_string};
-use tables::{ColumnDataDescription, ConcreteColumnDescription};
+use crate::stringutils::{self, status_to_string};
+use crate::tables::{ColumnDataDescription, ConcreteColumnDescription};
 
 /// Main entry point to the FITS file format
 pub struct FitsFile {
@@ -1038,14 +1038,14 @@ mod test {
 
     extern crate tempdir;
 
-    use errors::Error;
-    use fitsfile::FitsFile;
-    use fitsfile::{FileOpenMode, ImageDescription};
-    use hdu::{FitsHdu, HduInfo};
-    use images::ImageType;
+    use crate::errors::Error;
+    use crate::fitsfile::FitsFile;
+    use crate::fitsfile::{FileOpenMode, ImageDescription};
+    use crate::hdu::{FitsHdu, HduInfo};
+    use crate::images::ImageType;
     use std::path::Path;
-    use tables::{ColumnDataType, ColumnDescription};
-    use testhelpers::{duplicate_test_file, with_temp_file};
+    use crate::tables::{ColumnDataType, ColumnDescription};
+    use crate::testhelpers::{duplicate_test_file, with_temp_file};
 
     #[test]
     fn test_opening_an_existing_file() {

--- a/fitsio/src/hdu.rs
+++ b/fitsio/src/hdu.rs
@@ -6,12 +6,12 @@ use crate::fitsfile::FitsFile;
 use crate::headers::{ReadsKey, WritesKey};
 use crate::images::{ImageType, ReadImage, WriteImage};
 use crate::longnam::*;
-use std::ffi;
-use std::ops::Range;
 use crate::tables::{
     ColumnIterator, ConcreteColumnDescription, DescribesColumnLocation, FitsRow, ReadsCol,
     WritesCol,
 };
+use std::ffi;
+use std::ops::Range;
 
 /// Struct representing a FITS HDU
 #[derive(Debug, PartialEq)]
@@ -50,9 +50,7 @@ impl FitsHdu {
     # Example
 
     ```rust
-    # extern crate fitsio;
-    #
-    # fn try_main() -> Result<(), Box<std::error::Error>> {
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     # let filename = "../testdata/full_example.fits";
     # let mut fptr = fitsio::FitsFile::open(filename)?;
     # let hdu = fptr.primary_hdu()?;
@@ -61,7 +59,6 @@ impl FitsHdu {
     # }
     # Ok(())
     # }
-    # fn main() { try_main().unwrap(); }
     */
     pub fn read_key<T: ReadsKey>(&self, fits_file: &mut FitsFile, name: &str) -> Result<T> {
         fits_file.make_current(self)?;
@@ -74,9 +71,7 @@ impl FitsHdu {
     # Example
 
     ```rust
-    # extern crate tempdir;
-    # extern crate fitsio;
-    # fn try_main() -> Result<(), Box<std::error::Error>> {
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     # let tdir = tempdir::TempDir::new("fitsio-")?;
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
@@ -87,7 +82,6 @@ impl FitsHdu {
     # Ok(())
     # }
     # }
-    # fn main() { try_main().unwrap(); }
     ```
     */
     pub fn write_key<T: WritesKey>(
@@ -109,9 +103,7 @@ impl FitsHdu {
     # Example
 
     ```rust
-    # extern crate fitsio;
-    #
-    # fn try_main() -> Result<(), Box<std::error::Error>> {
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     # let filename = "../testdata/full_example.fits";
     # let mut fptr = fitsio::FitsFile::open(filename)?;
     # let hdu = fptr.hdu(0)?;
@@ -119,7 +111,6 @@ impl FitsHdu {
     let first_row: Vec<i32> = hdu.read_section(&mut fptr, 0, 100)?;
     # Ok(())
     # }
-    # fn main() { try_main().unwrap(); }
     ```
     */
     pub fn read_section<T: ReadImage>(
@@ -136,9 +127,7 @@ impl FitsHdu {
     # Example
 
     ```rust
-    # extern crate fitsio;
-    #
-    # fn try_main() -> Result<(), Box<std::error::Error>> {
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     # let filename = "../testdata/full_example.fits";
     # let mut fptr = fitsio::FitsFile::open(filename)?;
     # let hdu = fptr.hdu(0)?;
@@ -150,7 +139,6 @@ impl FitsHdu {
     assert_eq!(first_few_rows.len(), 1000);
     # Ok(())
     # }
-    # fn main() { try_main().unwrap(); }
     ```
     */
     pub fn read_rows<T: ReadImage>(
@@ -169,9 +157,7 @@ impl FitsHdu {
     # Example
 
     ```rust
-    # extern crate fitsio;
-    #
-    # fn try_main() -> Result<(), Box<std::error::Error>> {
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     # let filename = "../testdata/full_example.fits";
     # let mut fptr = fitsio::FitsFile::open(filename)?;
     # let hdu = fptr.hdu(0)?;
@@ -182,7 +168,6 @@ impl FitsHdu {
     assert_eq!(row.len(), 100);
     # Ok(())
     # }
-    # fn main() { try_main().unwrap(); }
     ```
     */
     pub fn read_row<T: ReadImage>(&self, fits_file: &mut FitsFile, row: usize) -> Result<T> {
@@ -200,9 +185,7 @@ impl FitsHdu {
     # Example
 
     ```rust
-    # extern crate fitsio;
-    #
-    # fn try_main() -> Result<(), Box<std::error::Error>> {
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     # let filename = "../testdata/full_example.fits";
     # let mut fptr = fitsio::FitsFile::open(filename)?;
     # let hdu = fptr.hdu(0)?;
@@ -212,7 +195,6 @@ impl FitsHdu {
     let chunk: Vec<i32> = hdu.read_region(&mut fptr, &[&ycoord, &xcoord])?;
     # Ok(())
     # }
-    # fn main() { try_main().unwrap(); }
     ```
     */
     pub fn read_region<T: ReadImage>(
@@ -232,9 +214,7 @@ impl FitsHdu {
     # Example
 
     ```rust
-    # extern crate fitsio;
-    #
-    # fn try_main() -> Result<(), Box<std::error::Error>> {
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     # let filename = "../testdata/full_example.fits";
     # let mut fptr = fitsio::FitsFile::open(filename)?;
     # let hdu = fptr.hdu(0)?;
@@ -244,7 +224,6 @@ impl FitsHdu {
     assert_eq!(image_data.len(), 10_000);
     # Ok(())
     # }
-    # fn main() { try_main().unwrap(); }
     ```
     */
     pub fn read_image<T: ReadImage>(&self, fits_file: &mut FitsFile) -> Result<T> {
@@ -263,11 +242,9 @@ impl FitsHdu {
     # Example
 
     ```rust
-    # extern crate fitsio;
-    # extern crate tempdir;
     # use fitsio::images::{ImageDescription, ImageType};
     #
-    # fn try_main() -> Result<(), Box<std::error::Error>> {
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     # let tdir = tempdir::TempDir::new("fitsio-")?;
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
@@ -281,7 +258,6 @@ impl FitsHdu {
     hdu.write_section(&mut fptr, 0, data_to_write.len(), &data_to_write)?;
     # Ok(())
     # }
-    # fn main() { try_main().unwrap(); }
     ```
     */
     pub fn write_section<T: WriteImage>(
@@ -307,11 +283,9 @@ impl FitsHdu {
     # Example
 
     ```rust
-    # extern crate fitsio;
-    # extern crate tempdir;
     # use fitsio::images::{ImageDescription, ImageType};
     #
-    # fn try_main() -> Result<(), Box<std::error::Error>> {
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     # let tdir = tempdir::TempDir::new("fitsio-")?;
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
@@ -326,7 +300,6 @@ impl FitsHdu {
     hdu.write_region(&mut fptr, &ranges, &data_to_write)?;
     # Ok(())
     # }
-    # fn main() { try_main().unwrap(); }
     ```
     */
     pub fn write_region<T: WriteImage>(
@@ -349,11 +322,9 @@ impl FitsHdu {
     ## Example
 
     ```rust
-    # extern crate fitsio;
-    # extern crate tempdir;
     # use fitsio::images::{ImageType, ImageDescription};
     #
-    # fn try_main() -> Result<(), Box<std::error::Error>> {
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     # let tdir = tempdir::TempDir::new("fitsio-")?;
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
@@ -368,7 +339,6 @@ impl FitsHdu {
     assert!(hdu.write_image(&mut fptr, &[1.0, 2.0, 3.0, 4.0]).is_err());
     # Ok(())
     # }
-    # fn main() { try_main().unwrap(); }
     ```
     */
     pub fn write_image<T: WriteImage>(&self, fits_file: &mut FitsFile, data: &[T]) -> Result<()> {
@@ -387,17 +357,15 @@ impl FitsHdu {
     ## Example
 
     ```rust
-    # extern crate tempdir;
-    # extern crate fitsio;
     # use std::fs::copy;
     use fitsio::hdu::HduInfo;
 
-    # fn try_main() -> Result<(), Box<std::error::Error>> {
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     # let tdir = tempdir::TempDir::new("fitsio-")?;
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
     # copy("../testdata/full_example.fits", &filename)?;
-    # let filename = filename.to_str().unwrap();
+    # let filename = filename.to_str().expect("creating string from filename");
     # let mut fptr = fitsio::FitsFile::edit(filename)?;
     # let hdu = fptr.hdu(0)?;
     hdu.resize(&mut fptr, &[1024, 1024])?;
@@ -412,7 +380,6 @@ impl FitsHdu {
     }
     # Ok(())
     # }
-    # fn main() { try_main().unwrap(); }
     ```
     */
     pub fn resize(self, fits_file: &mut FitsFile, new_size: &[usize]) -> Result<FitsHdu> {
@@ -447,9 +414,7 @@ impl FitsHdu {
     ## Example
 
     ```rust
-    # extern crate tempdir;
-    # extern crate fitsio;
-    # fn try_main() -> Result<(), Box<std::error::Error>> {
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     # let filename = "../testdata/full_example.fits";
     # let mut src_fptr = fitsio::FitsFile::open(filename)?;
     #
@@ -462,7 +427,6 @@ impl FitsHdu {
     hdu.copy_to(&mut src_fptr, &mut dest_fptr)?;
     # Ok(())
     # }
-    # fn main() { try_main().unwrap(); }
     ```
     */
     pub fn copy_to(
@@ -492,11 +456,9 @@ impl FitsHdu {
     ## Example
 
     ```rust
-    # extern crate fitsio;
-    # extern crate tempdir;
     use fitsio::tables::{ColumnDescription, ColumnDataType};
 
-    # fn try_main() -> Result<(), Box<std::error::Error>> {
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     # let tdir = tempdir::TempDir::new("fitsio-")?;
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
@@ -513,7 +475,6 @@ impl FitsHdu {
     hdu.insert_column(&mut fptr, 1, &column_description)?;
     # Ok(())
     # }
-    # fn main() { try_main().unwrap(); }
     ```
     */
     pub fn insert_column(
@@ -549,11 +510,9 @@ impl FitsHdu {
     ## Example
 
     ```rust
-    # extern crate fitsio;
-    # extern crate tempdir;
     use fitsio::tables::{ColumnDescription, ColumnDataType};
 
-    # fn try_main() -> Result<(), Box<std::error::Error>> {
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     # let tdir = tempdir::TempDir::new("fitsio-")?;
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
@@ -570,7 +529,6 @@ impl FitsHdu {
     hdu.append_column(&mut fptr, &column_description)?;
     # Ok(())
     # }
-    # fn main() { try_main().unwrap(); }
     ```
     */
     pub fn append_column(
@@ -608,12 +566,10 @@ impl FitsHdu {
     ## Example
 
     ```rust
-    # extern crate fitsio;
-    # extern crate tempdir;
     # use fitsio::FitsFile;
     # use fitsio::tables::{ColumnDescription, ColumnDataType};
 
-    # fn try_main() -> Result<(), Box<std::error::Error>> {
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     # {
     # let tdir = tempdir::TempDir::new("fitsio-")?;
     # let tdir_path = tdir.path();
@@ -643,7 +599,6 @@ impl FitsHdu {
     # }
     # Ok(())
     # }
-    # fn main() { try_main().unwrap(); }
     ```
     */
     pub fn delete_column<T: DescribesColumnLocation>(
@@ -708,12 +663,10 @@ impl FitsHdu {
     ## Example
 
     ```rust
-    # extern crate tempdir;
-    # extern crate fitsio;
     # use std::fs::copy;
     # use fitsio::hdu::HduInfo;
     # use fitsio::tables::{ColumnDescription, ColumnDataType};
-    # fn try_main() -> Result<(), Box<std::error::Error>> {
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     # let tdir = tempdir::TempDir::new("fitsio-")?;
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
@@ -730,7 +683,6 @@ impl FitsHdu {
     assert_eq!(data, vec![10101, 10101, 10101, 10101, 10101]);
     # Ok(())
     # }
-    # fn main() { try_main().unwrap(); }
     ```
     */
     pub fn read_col<T: ReadsCol>(&self, fits_file: &mut FitsFile, name: &str) -> Result<Vec<T>> {
@@ -746,12 +698,10 @@ impl FitsHdu {
     ## Example
 
     ```rust
-    # extern crate tempdir;
-    # extern crate fitsio;
     # use std::fs::copy;
     # use fitsio::hdu::HduInfo;
     # use fitsio::tables::{ColumnDescription, ColumnDataType};
-    # fn try_main() -> Result<(), Box<std::error::Error>> {
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     # let tdir = tempdir::TempDir::new("fitsio-")?;
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
@@ -768,7 +718,6 @@ impl FitsHdu {
     assert_eq!(data, vec![10101, 10101, 10101, 10101, 10101]);
     # Ok(())
     # }
-    # fn main() { try_main().unwrap(); }
     ```
     */
     pub fn read_col_range<T: ReadsCol>(
@@ -789,12 +738,10 @@ impl FitsHdu {
     ## Example
 
     ```rust
-    # extern crate tempdir;
-    # extern crate fitsio;
     # use std::fs::copy;
     # use fitsio::hdu::HduInfo;
     # use fitsio::tables::{ColumnDescription, ColumnDataType};
-    # fn try_main() -> Result<(), Box<std::error::Error>> {
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     # let tdir = tempdir::TempDir::new("fitsio-")?;
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
@@ -811,7 +758,6 @@ impl FitsHdu {
     # assert_eq!(data, vec![10101, 10101, 10101, 10101, 10101]);
     # Ok(())
     # }
-    # fn main() { try_main().unwrap(); }
     ```
     */
     pub fn write_col_range<T: WritesCol, N: Into<String>>(
@@ -836,12 +782,10 @@ impl FitsHdu {
     ## Example
 
     ```rust
-    # extern crate tempdir;
-    # extern crate fitsio;
     # use std::fs::copy;
     # use fitsio::hdu::HduInfo;
     # use fitsio::tables::{ColumnDescription, ColumnDataType};
-    # fn try_main() -> Result<(), Box<std::error::Error>> {
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     # let tdir = tempdir::TempDir::new("fitsio-")?;
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
@@ -860,7 +804,6 @@ impl FitsHdu {
     # assert_eq!(data, vec![10101, 10101, 10101, 10101, 10101]);
     # Ok(())
     # }
-    # fn main() { try_main().unwrap(); }
     ```
     */
     pub fn write_col<T: WritesCol, N: Into<String>>(
@@ -880,9 +823,7 @@ impl FitsHdu {
     ## Example
 
     ```rust
-    # extern crate fitsio;
-    #
-    # fn try_main() -> Result<(), Box<std::error::Error>> {
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     # let filename = "../testdata/full_example.fits";
     # let mut fptr = fitsio::FitsFile::open(filename)?;
     # let hdu = fptr.hdu("TESTEXT")?;
@@ -891,7 +832,6 @@ impl FitsHdu {
     }
     # Ok(())
     # }
-    # fn main() { try_main().unwrap(); }
     ```
     */
     pub fn columns<'a>(&self, fits_file: &'a mut FitsFile) -> ColumnIterator<'a> {
@@ -910,10 +850,8 @@ impl FitsHdu {
     ## Example
 
     ```rust
-    # extern crate tempdir;
-    # extern crate fitsio;
     # use fitsio::images::{ImageDescription, ImageType};
-    # fn try_main() -> Result<(), Box<std::error::Error>> {
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     # let tdir = tempdir::TempDir::new("fitsio-")?;
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
@@ -929,7 +867,6 @@ impl FitsHdu {
     // Cannot use hdu after this
     # Ok(())
     # }
-    # fn main() { try_main().unwrap(); }
     ```
     */
     pub fn delete(self, fits_file: &mut FitsFile) -> Result<()> {
@@ -951,8 +888,7 @@ impl FitsHdu {
     ## Example
 
     ```rust
-    # extern crate fitsio;
-    # fn try_main() -> Result<(), Box<std::error::Error>> {
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     # let filename = "../testdata/full_example.fits[TESTEXT]";
     # let mut f = fitsio::FitsFile::open(filename)?;
     # let tbl_hdu = f.hdu("TESTEXT")?;
@@ -963,7 +899,6 @@ impl FitsHdu {
     assert_eq!(result, "value4".to_string());
     # Ok(())
     # }
-    # fn main() { try_main().unwrap(); }
     ```
     */
     pub fn read_cell_value<T>(&self, fits_file: &mut FitsFile, name: &str, idx: usize) -> Result<T>
@@ -984,10 +919,8 @@ impl FitsHdu {
     # Example
 
     ```rust
-    #[macro_use]
-    extern crate fitsio_derive;
-    extern crate fitsio;
     use fitsio::tables::FitsRow;
+    use fitsio_derive::FitsRow;
 
     #[derive(Default, FitsRow)]
     struct Row {
@@ -997,15 +930,16 @@ impl FitsHdu {
         foobar: String,
     }
     #
-    # fn main() {
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     # let filename = "../testdata/full_example.fits[TESTEXT]";
-    # let mut f = fitsio::FitsFile::open(filename).unwrap();
-    # let hdu = f.hdu("TESTEXT").unwrap();
+    # let mut f = fitsio::FitsFile::open(filename)?;
+    # let hdu = f.hdu("TESTEXT")?;
 
     // Pick the 4th row
-    let row: Row = hdu.row(&mut f, 4).unwrap();
+    let row: Row = hdu.row(&mut f, 4)?;
     assert_eq!(row.intfoo, 16);
     assert_eq!(row.foobar, "value4");
+    # Ok(())
     # }
     ```
     */

--- a/fitsio/src/hdu.rs
+++ b/fitsio/src/hdu.rs
@@ -1,14 +1,14 @@
 //! Fits HDU related code
 
-use errors::{check_status, Result};
-use fitsfile::CaseSensitivity;
-use fitsfile::FitsFile;
-use headers::{ReadsKey, WritesKey};
-use images::{ImageType, ReadImage, WriteImage};
-use longnam::*;
+use crate::errors::{check_status, Result};
+use crate::fitsfile::CaseSensitivity;
+use crate::fitsfile::FitsFile;
+use crate::headers::{ReadsKey, WritesKey};
+use crate::images::{ImageType, ReadImage, WriteImage};
+use crate::longnam::*;
 use std::ffi;
 use std::ops::Range;
-use tables::{
+use crate::tables::{
     ColumnIterator, ConcreteColumnDescription, DescribesColumnLocation, FitsRow, ReadsCol,
     WritesCol,
 };
@@ -1130,8 +1130,8 @@ hduinfo_into_impl!(i64);
 #[cfg(test)]
 mod tests {
     use super::FitsFile;
-    use hdu::{FitsHdu, HduInfo};
-    use testhelpers::duplicate_test_file;
+    use crate::hdu::{FitsHdu, HduInfo};
+    use crate::testhelpers::duplicate_test_file;
 
     #[test]
     fn test_manually_creating_a_fits_hdu() {

--- a/fitsio/src/headers.rs
+++ b/fitsio/src/headers.rs
@@ -1,14 +1,14 @@
 //! Header-related code
-use errors::{check_status, Result};
-use fitsfile::FitsFile;
+use crate::errors::{check_status, Result};
+use crate::fitsfile::FitsFile;
 #[cfg(not(feature = "bindgen"))]
 use libc::*;
-use longnam::*;
+use crate::longnam::*;
 use std::ffi;
 #[cfg(feature = "bindgen")]
 use std::os::raw::*;
 use std::ptr;
-use types::DataType;
+use crate::types::DataType;
 
 const MAX_VALUE_LENGTH: usize = 71;
 
@@ -179,7 +179,7 @@ impl<'a> WritesKey for &'a str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use testhelpers::{duplicate_test_file, floats_close_f64, with_temp_file};
+    use crate::testhelpers::{duplicate_test_file, floats_close_f64, with_temp_file};
 
     #[test]
     fn test_reading_header_keys() {

--- a/fitsio/src/images.rs
+++ b/fitsio/src/images.rs
@@ -1,11 +1,11 @@
 //! Image related code
-use errors::{check_status, Result};
-use fitsfile::FitsFile;
-use hdu::{FitsHdu, HduInfo};
-use longnam::*;
+use crate::errors::{check_status, Result};
+use crate::fitsfile::FitsFile;
+use crate::hdu::{FitsHdu, HduInfo};
+use crate::longnam::*;
 use std::ops::Range;
 use std::ptr;
-use types::DataType;
+use crate::types::DataType;
 
 /// Reading fits images
 pub trait ReadImage: Sized {
@@ -370,8 +370,8 @@ imagetype_into_impl!(i64);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fitsfile::FitsFile;
-    use testhelpers::with_temp_file;
+    use crate::fitsfile::FitsFile;
+    use crate::testhelpers::with_temp_file;
 
     #[test]
     fn test_read_image_data() {

--- a/fitsio/src/lib.rs
+++ b/fitsio/src/lib.rs
@@ -59,8 +59,6 @@ Alternatively a new file can be created on disk with the companion method
 [`create`][fits-file-create]:
 
 ```rust
-# extern crate tempdir;
-# extern crate fitsio;
 # fn try_main() -> Result<(), Box<std::error::Error>> {
 # let tdir = tempdir::TempDir::new("fitsio-")?;
 # let tdir_path = tdir.path();
@@ -88,8 +86,6 @@ example of not adding a custom primary HDU is shown above. Below we see an examp
 [`with_custom_primary`][new-fits-file-with-custom-primary]:
 
 ```rust
-# extern crate tempdir;
-# extern crate fitsio;
 # fn try_main() -> Result<(), Box<std::error::Error>> {
 # let tdir = tempdir::TempDir::new("fitsio-")?;
 # let tdir_path = tdir.path();
@@ -171,11 +167,10 @@ HDU information belongs to the [`FitsHdu`][fits-hdu] object. HDUs can be fetched
 object contains information about the current HDU:
 
 ```rust
-# extern crate fitsio;
 # #[cfg(feature = "default")]
-# extern crate fitsio_sys as sys;
+# use fitsio_sys as sys;
 # #[cfg(feature = "bindgen")]
-# extern crate fitsio_sys_bindgen as sys;
+# use fitsio_sys_bindgen as sys;
 # use fitsio::FitsFile;
 #
 # fn try_main() -> Result<(), Box<std::error::Error>> {
@@ -213,8 +208,6 @@ method. This method requires the extension name, and an
 the desired image:
 
 ```rust
-# extern crate tempdir;
-# extern crate fitsio;
 # fn try_main() -> Result<(), Box<std::error::Error>> {
 # let tdir = tempdir::TempDir::new("fitsio-")?;
 # let tdir_path = tdir.path();
@@ -242,8 +235,6 @@ Similar to creating new images, new tables are created with the
 name, and a slice of [`ColumnDescription`][column-description]s:
 
 ```rust
-# extern crate tempdir;
-# extern crate fitsio;
 # fn try_main() -> Result<(), Box<std::error::Error>> {
 # let tdir = tempdir::TempDir::new("fitsio-")?;
 # let tdir_path = tdir.path();
@@ -280,7 +271,6 @@ For the common case of a scalar column, a `ColumnDataDescription` object can be 
 with the `scalar` method:
 
 ```rust
-# extern crate fitsio;
 # fn main() {
 use fitsio::tables::{ColumnDescription, ColumnDataDescription, ColumnDataType};
 
@@ -293,7 +283,6 @@ assert_eq!(desc.width, 1);
 Vector columns can be constructed with the `vector` method:
 
 ```rust
-# extern crate fitsio;
 # fn main() {
 use fitsio::tables::{ColumnDataDescription, ColumnDescription, ColumnDataType};
 
@@ -307,7 +296,6 @@ These impl `From<...> for String` such that the traditional fits column descript
 be obtained:
 
 ```rust
-# extern crate fitsio;
 # fn main() {
 use fitsio::tables::{ColumnDataDescription, ColumnDescription, ColumnDataType};
 
@@ -322,8 +310,6 @@ A HDU can be copied to another open file with the [`copy_to`][fits-hdu-copy-to] 
 requires another open [`FitsFile`][fits-file] object to copy to:
 
 ```rust
-# extern crate tempdir;
-# extern crate fitsio;
 # fn try_main() -> Result<(), Box<std::error::Error>> {
 # let filename = "../testdata/full_example.fits";
 # let mut src_fptr = fitsio::FitsFile::open(filename)?;
@@ -347,8 +333,6 @@ takes ownership of `self`, and as such the [`FitsHdu`][fits-hdu] object cannot b
 this is called.
 
 ```rust
-# extern crate tempdir;
-# extern crate fitsio;
 # use fitsio::images::{ImageType, ImageDescription};
 # fn try_main() -> Result<(), Box<std::error::Error>> {
 # let tdir = tempdir::TempDir::new("fitsio-")?;
@@ -374,7 +358,6 @@ hdu.delete(&mut fptr)?;
 The [`iter`][fits-hdu-iter] method allows for iteration over the HDUs of a fits file.
 
 ```rust
-# extern crate fitsio;
 # fn try_main() -> Result<(), Box<std::error::Error>> {
 #     let mut fptr = fitsio::FitsFile::open("../testdata/full_example.fits")?;
 for hdu in fptr.iter() {
@@ -396,8 +379,6 @@ Header keys are read through the [`read_key`][fits-hdu-read-key] function,
 and is generic over types that implement the [`ReadsKey`][reads-key] trait:
 
 ```rust
-# extern crate fitsio;
-#
 # fn try_main() -> Result<(), Box<std::error::Error>> {
 # let filename = "../testdata/full_example.fits";
 # let mut fptr = fitsio::FitsFile::open(filename)?;
@@ -421,8 +402,6 @@ Header cards can be written through the method
 `WritesKey`][writes-key] trait for supported data types.
 
 ```rust
-# extern crate tempdir;
-# extern crate fitsio;
 # fn try_main() -> Result<(), Box<std::error::Error>> {
 # let tdir = tempdir::TempDir::new("fitsio-")?;
 # let tdir_path = tdir.path();
@@ -451,8 +430,6 @@ between a start index and end index, or
 the image.
 
 ```rust
-# extern crate fitsio;
-#
 # fn try_main() -> Result<(), Box<std::error::Error>> {
 # let filename = "../testdata/full_example.fits";
 # let mut fptr = fitsio::FitsFile::open(filename)?;
@@ -476,8 +453,6 @@ Some convenience methods are available for reading rows of the image. This is
 typically useful as it's an efficient access method:
 
 ```rust
-# extern crate fitsio;
-#
 # fn try_main() -> Result<(), Box<std::error::Error>> {
 # let filename = "../testdata/full_example.fits";
 # let mut fptr = fitsio::FitsFile::open(filename)?;
@@ -496,8 +471,6 @@ assert_eq!(first_few_rows.len(), 1000);
 The whole image can also be read into memory:
 
 ```rust
-# extern crate fitsio;
-#
 # fn try_main() -> Result<(), Box<std::error::Error>> {
 # let filename = "../testdata/full_example.fits";
 # let mut fptr = fitsio::FitsFile::open(filename)?;
@@ -517,10 +490,6 @@ When `fitsio` is compiled with the `array` feature, images can be read into
 the [`ndarray::ArrayD`][arrayd] type:
 
 ```rust
-# extern crate fitsio;
-# #[cfg(feature = "array")]
-# extern crate ndarray;
-#
 # #[cfg(feature = "array")]
 # fn main() {
 use fitsio::FitsFile;
@@ -551,8 +520,6 @@ which can convert data types on the fly. See the [`ReadsCol`][reads-col] trait f
 supported data types.
 
 ```rust
-# extern crate fitsio;
-#
 # fn try_main() -> Result<(), Box<std::error::Error>> {
 # let filename = "../testdata/full_example.fits";
 # let mut fptr = fitsio::FitsFile::open(filename)?;
@@ -568,7 +535,6 @@ let integer_data: Vec<i32> = hdu.and_then(|hdu| hdu.read_col(&mut fptr, "intcol"
 Individual cell values can be read from FITS tables:
 
 ```rust
-# extern crate fitsio;
 # fn try_main() -> Result<(), Box<std::error::Error>> {
 # let filename = "../testdata/full_example.fits[TESTEXT]";
 # let mut f = fitsio::FitsFile::open(filename)?;
@@ -589,10 +555,8 @@ Single rows can be read from a fits table with the [`row`][fits-hdu-row] method.
 use of the [`fitsio-derive`][fitsio-derive] crate.
 
 ```rust
-#[macro_use]
-extern crate fitsio_derive;
-extern crate fitsio;
 use fitsio::tables::FitsRow;
+use fitsio_derive::FitsRow;
 
 #[derive(Default, FitsRow)]
 struct Row {
@@ -621,8 +585,6 @@ assert_eq!(row.foobar, "value4");
 Iterate over the columns with [`columns`][fits-hdu-columns].
 
 ```rust
-# extern crate fitsio;
-#
 # fn try_main() -> Result<(), Box<std::error::Error>> {
 # let filename = "../testdata/full_example.fits";
 # let mut fptr = fitsio::FitsFile::open(filename)?;
@@ -651,8 +613,6 @@ end index and data to write. The data parameter needs to be a slice, meaning any
 memory storage method (e.g. `Vec`) can be passed.
 
 ```rust
-# extern crate fitsio;
-# extern crate tempdir;
 # use fitsio::images::{ImageType, ImageDescription};
 #
 # fn try_main() -> Result<(), Box<std::error::Error>> {
@@ -676,8 +636,6 @@ hdu.write_section(&mut fptr, 0, data_to_write.len(), &data_to_write)?;
 the data is to be written, and the data to write.
 
 ```rust
-# extern crate fitsio;
-# extern crate tempdir;
 # use fitsio::images::{ImageType, ImageDescription};
 #
 # fn try_main() -> Result<(), Box<std::error::Error>> {
@@ -705,8 +663,6 @@ _Unlike cfitsio, the order of the ranges follows the C convention, i.e.
 image. If more data is passed than pixels in the image, the method returns with an error.
 
 ```rust
-# extern crate fitsio;
-# extern crate tempdir;
 # use fitsio::images::{ImageType, ImageDescription};
 #
 # fn try_main() -> Result<(), Box<std::error::Error>> {
@@ -737,8 +693,6 @@ currently `fitsio` only supports slices with length 2, i.e. a 2D image.
 again. This ensures the image changes are reflected in the hew HDU object.
 
 ```rust
-# extern crate tempdir;
-# extern crate fitsio;
 # use std::fs::copy;
 # fn try_main() -> Result<(), Box<std::error::Error>> {
 # let tdir = tempdir::TempDir::new("fitsio-")?;
@@ -780,8 +734,6 @@ not check how many rows are in the file, but extends the table if the length of 
 than the table length.
 
 ```rust
-# extern crate tempdir;
-# extern crate fitsio;
 # use std::fs::copy;
 # use fitsio::hdu::HduInfo;
 # use fitsio::tables::{ColumnDescription, ColumnDataType};
@@ -811,8 +763,6 @@ assert_eq!(data, vec![10101, 10101, 10101, 10101, 10101]);
 range is inclusive of both the upper and lower bounds, so `0..4` writes 5 elements.
 
 ```rust
-# extern crate tempdir;
-# extern crate fitsio;
 # use std::fs::copy;
 # use fitsio::hdu::HduInfo;
 # use fitsio::tables::{ColumnDescription, ColumnDataType};
@@ -846,8 +796,6 @@ generally
 preferred as it does not require shifting of data within the file.
 
 ```rust
-# extern crate fitsio;
-# extern crate tempdir;
 use fitsio::tables::{ColumnDescription, ColumnDataType};
 
 # fn try_main() -> Result<(), Box<std::error::Error>> {
@@ -876,8 +824,6 @@ The HDU object has the method [`delete_column`][fits-hdu-delete-column] which re
 The column can either be accessed by integer or name
 
 ```rust
-# extern crate fitsio;
-# extern crate tempdir;
 # use fitsio::tables::{ColumnDescription, ColumnDataType};
 # fn try_main() -> Result<(), Box<std::error::Error>> {
 # {
@@ -918,11 +864,10 @@ If this library does not support the particular use case that is needed, the raw
 pointer can be accessed:
 
 ```rust
-# extern crate fitsio;
 # #[cfg(not(feature="bindgen"))]
-extern crate fitsio_sys;
+# use fitsio_sys;
 # #[cfg(feature="bindgen")]
-# extern crate fitsio_sys_bindgen as fitsio_sys;
+# use fitsio_sys_bindgen as fitsio_sys;
 
 use fitsio::FitsFile;
 
@@ -966,7 +911,6 @@ subject to OS level limits, such as the maximum number of open files.
 ## Example
 
 ```rust
-# extern crate fitsio;
 # use fitsio::FitsFile;
 # use std::thread;
 # let fptr = FitsFile::open("../testdata/full_example.fits").unwrap();
@@ -1049,13 +993,11 @@ let _hdu = t.hdu(hdu_num).unwrap();
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 
+// If we are using the `bindgen` feature then import `fitsio_sys_bindgen` with a new name
 #[cfg(feature = "default")]
-extern crate fitsio_sys;
+use fitsio_sys;
 #[cfg(feature = "bindgen")]
-extern crate fitsio_sys_bindgen as fitsio_sys;
-extern crate libc;
-#[cfg(feature = "array")]
-extern crate ndarray;
+use fitsio_sys_bindgen as fitsio_sys;
 
 #[macro_use]
 mod macros;

--- a/fitsio/src/lib.rs
+++ b/fitsio/src/lib.rs
@@ -995,9 +995,9 @@ let _hdu = t.hdu(hdu_num).unwrap();
 
 // If we are using the `bindgen` feature then import `fitsio_sys_bindgen` with a new name
 #[cfg(feature = "default")]
-use fitsio_sys;
+use fitsio_sys as sys;
 #[cfg(feature = "bindgen")]
-use fitsio_sys_bindgen as fitsio_sys;
+use fitsio_sys_bindgen as sys;
 
 #[macro_use]
 mod macros;

--- a/fitsio/src/lib.rs
+++ b/fitsio/src/lib.rs
@@ -1078,7 +1078,7 @@ pub mod threadsafe_fitsfile;
 pub mod errors;
 
 // Re-exports
-pub use fitsfile::FitsFile;
+pub use crate::fitsfile::FitsFile;
 
 // For custom derive purposes
 // pub use tables::FitsRow;

--- a/fitsio/src/longnam.rs
+++ b/fitsio/src/longnam.rs
@@ -3,7 +3,7 @@
 // Disable clippy warnings as C uses long argument lists
 #![allow(clippy::too_many_arguments)]
 
-pub(crate) use crate::fitsio_sys::{
+pub(crate) use crate::sys::{
     ffclos, ffcopy, ffcrim, ffcrtb, ffdcol, ffdhdu, ffflmd, ffgbcl, ffgcdw, ffgcno, ffgcvd, ffgcve,
     ffgcvj, ffgcvk, ffgcvs, ffgcvuj, ffgcvuk, ffghdn, ffghdt, ffgidm, ffgiet, ffgisz, ffgkyd,
     ffgkye, ffgkyj, ffgkyl, ffgkys, ffgncl, ffgnrw, ffgpv, ffgsv, fficol, ffinit, ffmahd, ffmnhd,

--- a/fitsio/src/longnam.rs
+++ b/fitsio/src/longnam.rs
@@ -3,23 +3,23 @@
 // Disable clippy warnings as C uses long argument lists
 #![allow(clippy::too_many_arguments)]
 
-pub use fitsio_sys::{
+pub(crate) use crate::fitsio_sys::{
     ffclos, ffcopy, ffcrim, ffcrtb, ffdcol, ffdhdu, ffflmd, ffgbcl, ffgcdw, ffgcno, ffgcvd, ffgcve,
     ffgcvj, ffgcvk, ffgcvs, ffgcvuj, ffgcvuk, ffghdn, ffghdt, ffgidm, ffgiet, ffgisz, ffgkyd,
     ffgkye, ffgkyj, ffgkyl, ffgkys, ffgncl, ffgnrw, ffgpv, ffgsv, fficol, ffinit, ffmahd, ffmnhd,
-    ffopen, ffpcl, ffpcls, ffphps, ffpky, ffpkyd, ffpkye, ffpkyj, ffpkys, ffppr, ffpss, ffrsim,
-    ffthdu, fitsfile, LONGLONG,
+    ffopen, ffpcl, ffpcls, ffphps, ffpky, ffpkyd, ffpkye, ffpkys, ffppr, ffpss, ffrsim, ffthdu,
+    fitsfile, LONGLONG,
 };
 #[cfg(feature = "default")]
 use libc::{c_char, c_double, c_float, c_int, c_long, c_uint, c_ulong, c_void};
 #[cfg(feature = "bindgen")]
 use std::os::raw::{c_char, c_double, c_float, c_int, c_long, c_uint, c_ulong, c_void};
 
-pub unsafe fn fits_close_file(fptr: *mut fitsfile, status: *mut c_int) -> c_int {
+pub(crate) unsafe fn fits_close_file(fptr: *mut fitsfile, status: *mut c_int) -> c_int {
     ffclos(fptr, status)
 }
 
-pub unsafe fn fits_copy_hdu(
+pub(crate) unsafe fn fits_copy_hdu(
     infptr: *mut fitsfile,
     outfptr: *mut fitsfile,
     morekeys: c_int,
@@ -28,7 +28,7 @@ pub unsafe fn fits_copy_hdu(
     ffcopy(infptr, outfptr, morekeys, status)
 }
 
-pub unsafe fn fits_create_img(
+pub(crate) unsafe fn fits_create_img(
     fptr: *mut fitsfile,
     bitpix: c_int,
     naxis: c_int,
@@ -38,7 +38,7 @@ pub unsafe fn fits_create_img(
     ffcrim(fptr, bitpix, naxis, naxes, status)
 }
 
-pub unsafe fn fits_create_tbl(
+pub(crate) unsafe fn fits_create_tbl(
     fptr: *mut fitsfile,
     tbltype: c_int,
     naxis2: LONGLONG,
@@ -54,11 +54,15 @@ pub unsafe fn fits_create_tbl(
     )
 }
 
-pub unsafe fn fits_delete_col(fptr: *mut fitsfile, numcol: c_int, status: *mut c_int) -> c_int {
+pub(crate) unsafe fn fits_delete_col(
+    fptr: *mut fitsfile,
+    numcol: c_int,
+    status: *mut c_int,
+) -> c_int {
     ffdcol(fptr, numcol, status)
 }
 
-pub unsafe fn fits_delete_hdu(
+pub(crate) unsafe fn fits_delete_hdu(
     fptr: *mut fitsfile,
     hdutype: *mut c_int,
     status: *mut c_int,
@@ -66,7 +70,7 @@ pub unsafe fn fits_delete_hdu(
     ffdhdu(fptr, hdutype, status)
 }
 
-pub unsafe fn fits_file_mode(
+pub(crate) unsafe fn fits_file_mode(
     fptr: *mut fitsfile,
     filemode: *mut c_int,
     status: *mut c_int,
@@ -74,7 +78,7 @@ pub unsafe fn fits_file_mode(
     ffflmd(fptr, filemode, status)
 }
 
-pub unsafe fn fits_get_bcolparms(
+pub(crate) unsafe fn fits_get_bcolparms(
     fptr: *mut fitsfile,
     colnum: c_int,
     ttype: *mut c_char,
@@ -92,7 +96,7 @@ pub unsafe fn fits_get_bcolparms(
     )
 }
 
-pub unsafe fn fits_get_col_display_width(
+pub(crate) unsafe fn fits_get_col_display_width(
     fptr: *mut fitsfile,
     colnum: c_int,
     width: *mut c_int,
@@ -101,7 +105,7 @@ pub unsafe fn fits_get_col_display_width(
     ffgcdw(fptr, colnum, width, status)
 }
 
-pub unsafe fn fits_get_colnum(
+pub(crate) unsafe fn fits_get_colnum(
     fptr: *mut fitsfile,
     casesen: c_int,
     templt: *mut c_char,
@@ -111,7 +115,7 @@ pub unsafe fn fits_get_colnum(
     ffgcno(fptr, casesen, templt, colnum, status)
 }
 
-pub unsafe fn fits_read_col_str(
+pub(crate) unsafe fn fits_read_col_str(
     fptr: *mut fitsfile,
     colnum: c_int,
     firstrow: LONGLONG,
@@ -127,7 +131,7 @@ pub unsafe fn fits_read_col_str(
     )
 }
 
-pub unsafe fn fits_read_col_int(
+pub(crate) unsafe fn fits_read_col_int(
     fptr: *mut fitsfile,
     colnum: c_int,
     firstrow: LONGLONG,
@@ -143,7 +147,7 @@ pub unsafe fn fits_read_col_int(
     )
 }
 
-pub unsafe fn fits_read_col_uint(
+pub(crate) unsafe fn fits_read_col_uint(
     fptr: *mut fitsfile,
     colnum: c_int,
     firstrow: LONGLONG,
@@ -159,7 +163,7 @@ pub unsafe fn fits_read_col_uint(
     )
 }
 
-pub unsafe fn fits_read_col_flt(
+pub(crate) unsafe fn fits_read_col_flt(
     fptr: *mut fitsfile,
     colnum: c_int,
     firstrow: LONGLONG,
@@ -175,7 +179,7 @@ pub unsafe fn fits_read_col_flt(
     )
 }
 
-pub unsafe fn fits_read_col_dbl(
+pub(crate) unsafe fn fits_read_col_dbl(
     fptr: *mut fitsfile,
     colnum: c_int,
     firstrow: LONGLONG,
@@ -191,7 +195,7 @@ pub unsafe fn fits_read_col_dbl(
     )
 }
 
-pub unsafe fn fits_read_col_lng(
+pub(crate) unsafe fn fits_read_col_lng(
     fptr: *mut fitsfile,
     colnum: c_int,
     firstrow: LONGLONG,
@@ -207,7 +211,7 @@ pub unsafe fn fits_read_col_lng(
     )
 }
 
-pub unsafe fn fits_read_col_ulng(
+pub(crate) unsafe fn fits_read_col_ulng(
     fptr: *mut fitsfile,
     colnum: c_int,
     firstrow: LONGLONG,
@@ -223,7 +227,7 @@ pub unsafe fn fits_read_col_ulng(
     )
 }
 
-pub unsafe fn fits_read_key_log(
+pub(crate) unsafe fn fits_read_key_log(
     fptr: *mut fitsfile,
     keyname: *const c_char,
     value: *mut c_int,
@@ -233,7 +237,7 @@ pub unsafe fn fits_read_key_log(
     ffgkyl(fptr, keyname, value, comm, status)
 }
 
-pub unsafe fn fits_read_key_lng(
+pub(crate) unsafe fn fits_read_key_lng(
     fptr: *mut fitsfile,
     keyname: *const c_char,
     value: *mut c_long,
@@ -243,7 +247,7 @@ pub unsafe fn fits_read_key_lng(
     ffgkyj(fptr, keyname, value, comm, status)
 }
 
-pub unsafe fn fits_read_key_flt(
+pub(crate) unsafe fn fits_read_key_flt(
     fptr: *mut fitsfile,
     keyname: *const c_char,
     value: *mut c_float,
@@ -253,7 +257,7 @@ pub unsafe fn fits_read_key_flt(
     ffgkye(fptr, keyname, value, comm, status)
 }
 
-pub unsafe fn fits_read_key_dbl(
+pub(crate) unsafe fn fits_read_key_dbl(
     fptr: *mut fitsfile,
     keyname: *const c_char,
     value: *mut c_double,
@@ -263,11 +267,11 @@ pub unsafe fn fits_read_key_dbl(
     ffgkyd(fptr, keyname, value, comm, status)
 }
 
-pub unsafe fn fits_get_hdu_num(fptr: *mut fitsfile, chdunum: *mut c_int) -> c_int {
+pub(crate) unsafe fn fits_get_hdu_num(fptr: *mut fitsfile, chdunum: *mut c_int) -> c_int {
     ffghdn(fptr, chdunum)
 }
 
-pub unsafe fn fits_get_hdu_type(
+pub(crate) unsafe fn fits_get_hdu_type(
     fptr: *mut fitsfile,
     exttype: *mut c_int,
     status: *mut c_int,
@@ -275,7 +279,7 @@ pub unsafe fn fits_get_hdu_type(
     ffghdt(fptr, exttype, status)
 }
 
-pub unsafe fn fits_get_img_dim(
+pub(crate) unsafe fn fits_get_img_dim(
     fptr: *mut fitsfile,
     naxis: *mut c_int,
     status: *mut c_int,
@@ -283,7 +287,7 @@ pub unsafe fn fits_get_img_dim(
     ffgidm(fptr, naxis, status)
 }
 
-pub unsafe fn fits_get_img_equivtype(
+pub(crate) unsafe fn fits_get_img_equivtype(
     fptr: *mut fitsfile,
     imgtype: *mut c_int,
     status: *mut c_int,
@@ -291,7 +295,7 @@ pub unsafe fn fits_get_img_equivtype(
     ffgiet(fptr, imgtype, status)
 }
 
-pub unsafe fn fits_get_img_size(
+pub(crate) unsafe fn fits_get_img_size(
     fptr: *mut fitsfile,
     nlen: c_int,
     naxes: *mut c_long,
@@ -300,7 +304,7 @@ pub unsafe fn fits_get_img_size(
     ffgisz(fptr, nlen, naxes, status)
 }
 
-pub unsafe fn fits_read_key_str(
+pub(crate) unsafe fn fits_read_key_str(
     fptr: *mut fitsfile,
     keyname: *const c_char,
     value: *mut c_char,
@@ -310,7 +314,7 @@ pub unsafe fn fits_read_key_str(
     ffgkys(fptr, keyname, value, comm, status)
 }
 
-pub unsafe fn fits_get_num_cols(
+pub(crate) unsafe fn fits_get_num_cols(
     fptr: *mut fitsfile,
     ncols: *mut c_int,
     status: *mut c_int,
@@ -318,7 +322,7 @@ pub unsafe fn fits_get_num_cols(
     ffgncl(fptr, ncols, status)
 }
 
-pub unsafe fn fits_get_num_rows(
+pub(crate) unsafe fn fits_get_num_rows(
     fptr: *mut fitsfile,
     nrows: *mut c_long,
     status: *mut c_int,
@@ -326,7 +330,7 @@ pub unsafe fn fits_get_num_rows(
     ffgnrw(fptr, nrows, status)
 }
 
-pub unsafe fn fits_read_img(
+pub(crate) unsafe fn fits_read_img(
     fptr: *mut fitsfile,
     datatype: c_int,
     firstelem: LONGLONG,
@@ -341,7 +345,7 @@ pub unsafe fn fits_read_img(
     )
 }
 
-pub unsafe fn fits_read_subset(
+pub(crate) unsafe fn fits_read_subset(
     fptr: *mut fitsfile,
     datatype: c_int,
     blc: *mut c_long,
@@ -355,7 +359,7 @@ pub unsafe fn fits_read_subset(
     ffgsv(fptr, datatype, blc, trc, inc, nulval, array, anynul, status)
 }
 
-pub unsafe fn fits_insert_col(
+pub(crate) unsafe fn fits_insert_col(
     fptr: *mut fitsfile,
     numcol: c_int,
     ttype: *mut c_char,
@@ -365,7 +369,7 @@ pub unsafe fn fits_insert_col(
     fficol(fptr, numcol, ttype, tform, status)
 }
 
-pub unsafe fn fits_movabs_hdu(
+pub(crate) unsafe fn fits_movabs_hdu(
     fptr: *mut fitsfile,
     hdunum: c_int,
     exttype: *mut c_int,
@@ -374,7 +378,7 @@ pub unsafe fn fits_movabs_hdu(
     ffmahd(fptr, hdunum, exttype, status)
 }
 
-pub unsafe fn fits_movnam_hdu(
+pub(crate) unsafe fn fits_movnam_hdu(
     fptr: *mut fitsfile,
     exttype: c_int,
     hduname: *mut c_char,
@@ -384,7 +388,7 @@ pub unsafe fn fits_movnam_hdu(
     ffmnhd(fptr, exttype, hduname, hduvers, status)
 }
 
-pub unsafe fn fits_create_file(
+pub(crate) unsafe fn fits_create_file(
     fptr: *mut *mut fitsfile,
     filename: *const c_char,
     status: *mut c_int,
@@ -392,7 +396,7 @@ pub unsafe fn fits_create_file(
     ffinit(fptr, filename, status)
 }
 
-pub unsafe fn fits_write_col(
+pub(crate) unsafe fn fits_write_col(
     fptr: *mut fitsfile,
     datatype: c_int,
     colnum: c_int,
@@ -407,7 +411,7 @@ pub unsafe fn fits_write_col(
     )
 }
 
-pub unsafe fn fits_write_col_str(
+pub(crate) unsafe fn fits_write_col_str(
     fptr: *mut fitsfile,
     colnum: c_int,
     firstrow: LONGLONG,
@@ -419,7 +423,7 @@ pub unsafe fn fits_write_col_str(
     ffpcls(fptr, colnum, firstrow, firstelem, nelem, array, status)
 }
 
-pub unsafe fn fits_write_imghdr(
+pub(crate) unsafe fn fits_write_imghdr(
     fptr: *mut fitsfile,
     bitpix: c_int,
     naxis: c_int,
@@ -429,7 +433,7 @@ pub unsafe fn fits_write_imghdr(
     ffphps(fptr, bitpix, naxis, naxes, status)
 }
 
-pub unsafe fn fits_write_key_flt(
+pub(crate) unsafe fn fits_write_key_flt(
     fptr: *mut fitsfile,
     keyname: *const c_char,
     value: c_float,
@@ -440,7 +444,7 @@ pub unsafe fn fits_write_key_flt(
     ffpkye(fptr, keyname, value, decim, comm, status)
 }
 
-pub unsafe fn fits_write_key_dbl(
+pub(crate) unsafe fn fits_write_key_dbl(
     fptr: *mut fitsfile,
     keyname: *const c_char,
     value: c_double,
@@ -450,7 +454,7 @@ pub unsafe fn fits_write_key_dbl(
 ) -> c_int {
     ffpkyd(fptr, keyname, value, decim, comm, status)
 }
-pub unsafe fn fits_write_key_str(
+pub(crate) unsafe fn fits_write_key_str(
     fptr: *mut fitsfile,
     keyname: *const c_char,
     value: *const c_char,
@@ -460,7 +464,7 @@ pub unsafe fn fits_write_key_str(
     ffpkys(fptr, keyname, value, comm, status)
 }
 
-pub unsafe fn fits_write_img(
+pub(crate) unsafe fn fits_write_img(
     fptr: *mut fitsfile,
     datatype: c_int,
     firstelem: LONGLONG,
@@ -471,7 +475,7 @@ pub unsafe fn fits_write_img(
     ffppr(fptr, datatype, firstelem, nelem, array, status)
 }
 
-pub unsafe fn fits_write_subset(
+pub(crate) unsafe fn fits_write_subset(
     fptr: *mut fitsfile,
     datatype: c_int,
     fpixel: *mut c_long,
@@ -482,7 +486,7 @@ pub unsafe fn fits_write_subset(
     ffpss(fptr, datatype, fpixel, lpixel, array, status)
 }
 
-pub unsafe fn fits_resize_img(
+pub(crate) unsafe fn fits_resize_img(
     fptr: *mut fitsfile,
     bitpix: c_int,
     naxis: c_int,
@@ -492,7 +496,7 @@ pub unsafe fn fits_resize_img(
     ffrsim(fptr, bitpix, naxis, naxes, status)
 }
 
-pub unsafe fn fits_get_num_hdus(
+pub(crate) unsafe fn fits_get_num_hdus(
     fptr: *mut fitsfile,
     nhdu: *mut c_int,
     status: *mut c_int,
@@ -500,7 +504,7 @@ pub unsafe fn fits_get_num_hdus(
     ffthdu(fptr, nhdu, status)
 }
 
-pub unsafe fn fits_open_file(
+pub(crate) unsafe fn fits_open_file(
     fptr: *mut *mut fitsfile,
     filename: *const c_char,
     iomode: c_int,
@@ -509,7 +513,7 @@ pub unsafe fn fits_open_file(
     ffopen(fptr, filename, iomode, status)
 }
 
-pub unsafe fn fits_write_key(
+pub(crate) unsafe fn fits_write_key(
     fptr: *mut fitsfile,
     datatype: c_int,
     keyname: *const c_char,

--- a/fitsio/src/ndarray_compat.rs
+++ b/fitsio/src/ndarray_compat.rs
@@ -167,10 +167,10 @@ assert_eq!(data[[0, 10]], 160);
 [read-section]: images/struct.FitsHdu.html#method.read_section
 */
 
-use errors::Result;
-use fitsfile::FitsFile;
-use hdu::{FitsHdu, HduInfo};
-use images::ReadImage;
+use crate::errors::Result;
+use crate::fitsfile::FitsFile;
+use crate::hdu::{FitsHdu, HduInfo};
+use crate::images::ReadImage;
 use ndarray::{Array, ArrayD};
 use std::ops::Range;
 

--- a/fitsio/src/ndarray_compat.rs
+++ b/fitsio/src/ndarray_compat.rs
@@ -217,7 +217,7 @@ where
         num_rows: usize,
     ) -> Result<Self> {
         let data: Vec<T> = ReadImage::read_rows(fits_file, hdu, start_row, num_rows)?;
-        let arr = Array::from_vec(data);
+        let arr = Array::from(data);
         let row_length = arr.len() / num_rows;
         Ok(arr.into_shape(vec![num_rows, row_length]).unwrap())
     }

--- a/fitsio/src/ndarray_compat.rs
+++ b/fitsio/src/ndarray_compat.rs
@@ -17,9 +17,6 @@ Data is read into the [`ndarray::ArrayD`][arrayd] type. The following methods fr
 ## `read_image`
 
 ```rust
-# extern crate fitsio;
-# #[cfg(feature = "array")]
-# extern crate ndarray;
 use fitsio::FitsFile;
 # #[cfg(feature = "array")]
 use ndarray::ArrayD;
@@ -44,9 +41,6 @@ assert_eq!(data[[20, 5]], 152);
 ## `read_region`
 
 ```rust
-# extern crate fitsio;
-# #[cfg(feature = "array")]
-# extern crate ndarray;
 use fitsio::FitsFile;
 # #[cfg(feature = "array")]
 use ndarray::ArrayD;
@@ -71,9 +65,6 @@ assert_eq!(data[[5, 10]], 177);
 ## `read_row`
 
 ```rust
-# extern crate fitsio;
-# #[cfg(feature = "array")]
-# extern crate ndarray;
 use fitsio::FitsFile;
 # #[cfg(feature = "array")]
 use ndarray::ArrayD;
@@ -95,9 +86,6 @@ assert_eq!(data[20], 156);
 ## `read_rows`
 
 ```rust
-# extern crate fitsio;
-# #[cfg(feature = "array")]
-# extern crate ndarray;
 use fitsio::FitsFile;
 # #[cfg(feature = "array")]
 use ndarray::ArrayD;
@@ -122,9 +110,6 @@ assert_eq!(data[[1, 52]], 184);
 ## `read_section`
 
 ```rust
-# extern crate fitsio;
-# #[cfg(feature = "array")]
-# extern crate ndarray;
 use fitsio::FitsFile;
 use fitsio::errors::Error;
 # #[cfg(feature = "array")]

--- a/fitsio/src/stringutils.rs
+++ b/fitsio/src/stringutils.rs
@@ -1,5 +1,5 @@
 use crate::errors::Result;
-use fitsio_sys::ffgerr;
+use crate::fitsio_sys::ffgerr;
 use libc::{c_char, c_int, size_t};
 use std::ffi::{CStr, CString};
 

--- a/fitsio/src/stringutils.rs
+++ b/fitsio/src/stringutils.rs
@@ -1,4 +1,4 @@
-use errors::Result;
+use crate::errors::Result;
 use fitsio_sys::ffgerr;
 use libc::{c_char, c_int, size_t};
 use std::ffi::{CStr, CString};

--- a/fitsio/src/stringutils.rs
+++ b/fitsio/src/stringutils.rs
@@ -1,5 +1,5 @@
 use crate::errors::Result;
-use crate::fitsio_sys::ffgerr;
+use crate::sys::ffgerr;
 use libc::{c_char, c_int, size_t};
 use std::ffi::{CStr, CString};
 

--- a/fitsio/src/tables.rs
+++ b/fitsio/src/tables.rs
@@ -2,14 +2,13 @@
 use crate::errors::{check_status, Error, FitsError, IndexError, Result};
 use crate::fitsfile::FitsFile;
 use crate::hdu::{FitsHdu, HduInfo};
-use libc;
 use crate::longnam::*;
+use crate::stringutils::status_to_string;
+use crate::types::DataType;
 use std::ffi;
 use std::ops::Range;
 use std::ptr;
 use std::str::FromStr;
-use crate::stringutils::status_to_string;
-use crate::types::DataType;
 
 /// Trait for reading a fits column
 pub trait ReadsCol {
@@ -761,7 +760,9 @@ impl<'a> Iterator for ColumnIterator<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::testhelpers::{duplicate_test_file, floats_close_f32, floats_close_f64, with_temp_file};
+    use crate::testhelpers::{
+        duplicate_test_file, floats_close_f32, floats_close_f64, with_temp_file,
+    };
 
     #[test]
     fn test_parsing() {

--- a/fitsio/src/tables.rs
+++ b/fitsio/src/tables.rs
@@ -1,15 +1,15 @@
 //! Table-related code
-use errors::{check_status, Error, FitsError, IndexError, Result};
-use fitsfile::FitsFile;
-use hdu::{FitsHdu, HduInfo};
+use crate::errors::{check_status, Error, FitsError, IndexError, Result};
+use crate::fitsfile::FitsFile;
+use crate::hdu::{FitsHdu, HduInfo};
 use libc;
-use longnam::*;
+use crate::longnam::*;
 use std::ffi;
 use std::ops::Range;
 use std::ptr;
 use std::str::FromStr;
-use stringutils::status_to_string;
-use types::DataType;
+use crate::stringutils::status_to_string;
+use crate::types::DataType;
 
 /// Trait for reading a fits column
 pub trait ReadsCol {
@@ -761,7 +761,7 @@ impl<'a> Iterator for ColumnIterator<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use testhelpers::{duplicate_test_file, floats_close_f32, floats_close_f64, with_temp_file};
+    use crate::testhelpers::{duplicate_test_file, floats_close_f32, floats_close_f64, with_temp_file};
 
     #[test]
     fn test_parsing() {

--- a/fitsio/src/testhelpers.rs
+++ b/fitsio/src/testhelpers.rs
@@ -1,5 +1,3 @@
-extern crate tempdir;
-
 use std::{f32, f64};
 
 /// Function to allow access to a temporary file

--- a/fitsio/src/threadsafe_fitsfile.rs
+++ b/fitsio/src/threadsafe_fitsfile.rs
@@ -1,7 +1,7 @@
 /*! Thread-safe FitsFile struct */
 
-use errors::Result;
-use fitsfile::FitsFile;
+use crate::errors::Result;
+use crate::fitsfile::FitsFile;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 /** Thread-safe [`FitsFile`][fits-file] representation.

--- a/fitsio/src/types.rs
+++ b/fitsio/src/types.rs
@@ -25,10 +25,10 @@ pub enum DataType {
 
 #[cfg(test)]
 mod test {
-    use fitsfile::{CaseSensitivity, FileOpenMode};
-    use hdu::HduInfo;
-    use images::ImageType;
-    use types::DataType;
+    use crate::fitsfile::{CaseSensitivity, FileOpenMode};
+    use crate::hdu::HduInfo;
+    use crate::images::ImageType;
+    use crate::types::DataType;
 
     #[test]
     fn test_image_types() {

--- a/fitsio/tests/test_custom_derive.rs
+++ b/fitsio/tests/test_custom_derive.rs
@@ -1,11 +1,8 @@
 /* Custom derives
 */
-extern crate fitsio;
-#[macro_use]
-extern crate fitsio_derive;
-
 use fitsio::tables::FitsRow;
 use fitsio::FitsFile;
+use fitsio_derive::FitsRow;
 
 #[derive(Default, FitsRow)]
 struct Row {

--- a/fitsio/tests/test_square_array.rs
+++ b/fitsio/tests/test_square_array.rs
@@ -1,5 +1,3 @@
-extern crate fitsio;
-
 use fitsio::FitsFile;
 
 #[test]

--- a/fitsio/tests/test_ushort.rs
+++ b/fitsio/tests/test_ushort.rs
@@ -3,8 +3,6 @@
  *
  *
  */
-extern crate fitsio;
-
 use fitsio::hdu::HduInfo;
 use fitsio::images::ImageType;
 use fitsio::FitsFile;

--- a/fitsio/tests/test_version_numbers.rs
+++ b/fitsio/tests/test_version_numbers.rs
@@ -3,15 +3,12 @@
 // These tests will make sure the version numbers in the readme and main crate documentation stay
 // in sync with the crate version number
 
-#[macro_use]
-extern crate version_sync;
-
 #[test]
 fn test_readme_deps() {
-    assert_markdown_deps_updated!("../README.md");
+    version_sync::assert_markdown_deps_updated!("../README.md");
 }
 
 #[test]
 fn test_html_root_url() {
-    assert_html_root_url_updated!("src/lib.rs");
+    version_sync::assert_html_root_url_updated!("src/lib.rs");
 }

--- a/homepage/fitsioexample/Cargo.toml
+++ b/homepage/fitsioexample/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "fitsioexample"
+edition = "2018"
 version = "0.1.0"
 authors = ["Simon Walker <s.r.walker101@googlemail.com>"]
 

--- a/homepage/fitsioexample/src/bin/ndarray_support.rs
+++ b/homepage/fitsioexample/src/bin/ndarray_support.rs
@@ -1,6 +1,3 @@
-extern crate fitsio;
-extern crate ndarray;
-
 use fitsio::FitsFile;
 use ndarray::ArrayD;
 use std::error::Error;

--- a/homepage/fitsioexample/src/main.rs
+++ b/homepage/fitsioexample/src/main.rs
@@ -1,5 +1,3 @@
-extern crate fitsio;
-
 use fitsio::FitsFile;
 use std::error::Error;
 


### PR DESCRIPTION
Given this does not impact users of this crate, we should be using 2018
edition wherever possible.