### PR TITLE
Replace tempdir with tempfile

### DIFF
--- a/fitsio-sys-bindgen/Cargo.toml
+++ b/fitsio-sys-bindgen/Cargo.toml
@@ -17,7 +17,7 @@ libc = "0"
 block = "0"
 
 [dev-dependencies]
-tempdir = "0"
+tempfile = "3.1.0"
 
 [build-dependencies]
 pkg-config = "0"

--- a/fitsio-sys-bindgen/src/lib.rs
+++ b/fitsio-sys-bindgen/src/lib.rs
@@ -97,7 +97,10 @@ mod test {
     #[test]
     fn raw_creating_a_new_file() {
         // Set up the test filename
-        let tdir = tempdir::TempDir::new("rust-fitsio-").unwrap();
+        let tdir = tempfile::Builder::new()
+            .prefix("fitsio-")
+            .tempdir()
+            .unwrap();
         let filename = tdir.path().join("test.fits");
         assert!(!filename.exists());
 

--- a/fitsio/Cargo.toml
+++ b/fitsio/Cargo.toml
@@ -23,7 +23,7 @@ clippy = { version = "0", optional = true }
 ndarray = { version = "0", optional = true }
 
 [dev-dependencies]
-tempdir = "0.3.4"
+tempfile = "3.1.0"
 fitsio-derive = { version = "0.1.0", path = "../fitsio-derive" }
 version-sync = "0.8.1"
 criterion = "0.3.0"

--- a/fitsio/benches/benchmarks.rs
+++ b/fitsio/benches/benchmarks.rs
@@ -3,7 +3,7 @@ use fitsio::images::{ImageDescription, ImageType};
 use fitsio::tables::{ColumnDataType, ColumnDescription, FitsRow};
 use fitsio::FitsFile;
 use fitsio_derive::FitsRow;
-use tempdir::TempDir;
+use tempfile::Builder;
 
 fn opening_files(c: &mut Criterion) {
     let filename = "../testdata/full_example.fits";

--- a/fitsio/examples/full_example.rs
+++ b/fitsio/examples/full_example.rs
@@ -12,16 +12,16 @@
  */
 
 use std::error::Error;
-use tempdir::TempDir;
 
 use fitsio::images::{ImageDescription, ImageType};
 use fitsio::tables::{ColumnDataType, ColumnDescription, FitsRow};
 use fitsio::FitsFile;
 use fitsio_derive::FitsRow;
+use tempfile::Builder;
 
 fn run() -> Result<(), Box<dyn Error>> {
     /* Create a temporary directory to work from */
-    let tmp_dir = TempDir::new("fitsio")?;
+    let tmp_dir = Builder::new().prefix("fitsio-").tempdir()?;
     let file_path = tmp_dir.path().join("example.fits");
 
     // creating a new file with 512 rows and 1024 columns

--- a/fitsio/src/fitsfile.rs
+++ b/fitsio/src/fitsfile.rs
@@ -128,7 +128,7 @@ impl FitsFile {
 
     ```rust
     # fn main() -> Result<(), Box<std::error::Error>> {
-    # let tdir = tempdir::TempDir::new("fitsio-").unwrap();
+    # let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
     use fitsio::FitsFile;
@@ -422,7 +422,7 @@ impl FitsFile {
     use fitsio::tables::{ColumnDataType, ColumnDescription};
 
     # fn main() -> Result<(), Box<std::error::Error>> {
-    # let tdir = tempdir::TempDir::new("fitsio-")?;
+    # let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
     # let mut fptr = fitsio::FitsFile::create(filename).open()?;
@@ -503,7 +503,7 @@ impl FitsFile {
     use fitsio::images::{ImageDescription, ImageType};
 
     # fn main() -> Result<(), Box<std::error::Error>> {
-    # let tdir = tempdir::TempDir::new("fitsio-")?;
+    # let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
     # let mut fptr = fitsio::FitsFile::create(filename).open()?;
@@ -778,7 +778,7 @@ custom primary HDU.
 # Example
 
 ```rust
-# let tdir = tempdir::TempDir::new("fitsio-").unwrap();
+# let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
 # let tdir_path = tdir.path();
 # let _filename = tdir_path.join("test.fits");
 # let filename = _filename.to_str().unwrap();
@@ -802,7 +802,7 @@ temporary representation.
 # Example
 
 ```rust
-# let tdir = tempdir::TempDir::new("fitsio-").unwrap();
+# let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
 # let tdir_path = tdir.path();
 # let _filename = tdir_path.join("test.fits");
 # let filename = _filename.to_str().unwrap();
@@ -885,7 +885,7 @@ where
 
     ```rust
     # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # let tdir = tempdir::TempDir::new("fitsio-")?;
+    # let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
     use fitsio::FitsFile;
@@ -926,7 +926,7 @@ where
 
     ```rust
     # fn main() -> Result<(), Box<std::error::Error>> {
-    # let tdir = tempdir::TempDir::new("fitsio-")?;
+    # let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
     use fitsio::FitsFile;

--- a/fitsio/src/hdu.rs
+++ b/fitsio/src/hdu.rs
@@ -72,7 +72,7 @@ impl FitsHdu {
 
     ```rust
     # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # let tdir = tempdir::TempDir::new("fitsio-")?;
+    # let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
     # {
@@ -245,7 +245,7 @@ impl FitsHdu {
     # use fitsio::images::{ImageDescription, ImageType};
     #
     # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # let tdir = tempdir::TempDir::new("fitsio-")?;
+    # let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
     # let mut fptr = fitsio::FitsFile::create(filename).open()?;
@@ -286,7 +286,7 @@ impl FitsHdu {
     # use fitsio::images::{ImageDescription, ImageType};
     #
     # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # let tdir = tempdir::TempDir::new("fitsio-")?;
+    # let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
     # let mut fptr = fitsio::FitsFile::create(filename).open()?;
@@ -325,7 +325,7 @@ impl FitsHdu {
     # use fitsio::images::{ImageType, ImageDescription};
     #
     # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # let tdir = tempdir::TempDir::new("fitsio-")?;
+    # let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
     # let mut fptr = fitsio::FitsFile::create(filename).open()?;
@@ -361,7 +361,7 @@ impl FitsHdu {
     use fitsio::hdu::HduInfo;
 
     # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # let tdir = tempdir::TempDir::new("fitsio-")?;
+    # let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
     # copy("../testdata/full_example.fits", &filename)?;
@@ -418,7 +418,7 @@ impl FitsHdu {
     # let filename = "../testdata/full_example.fits";
     # let mut src_fptr = fitsio::FitsFile::open(filename)?;
     #
-    # let tdir = tempdir::TempDir::new("fitsio-")?;
+    # let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
     # let mut dest_fptr = fitsio::FitsFile::create(filename).open()?;
@@ -459,7 +459,7 @@ impl FitsHdu {
     use fitsio::tables::{ColumnDescription, ColumnDataType};
 
     # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # let tdir = tempdir::TempDir::new("fitsio-")?;
+    # let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
     # let mut fptr = fitsio::FitsFile::create(filename).open()?;
@@ -513,7 +513,7 @@ impl FitsHdu {
     use fitsio::tables::{ColumnDescription, ColumnDataType};
 
     # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # let tdir = tempdir::TempDir::new("fitsio-")?;
+    # let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
     # let mut fptr = fitsio::FitsFile::create(filename).open()?;
@@ -571,7 +571,7 @@ impl FitsHdu {
 
     # fn main() -> Result<(), Box<dyn std::error::Error>> {
     # {
-    # let tdir = tempdir::TempDir::new("fitsio-")?;
+    # let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
     # let mut fptr = FitsFile::create(filename).open()?;
@@ -584,7 +584,7 @@ impl FitsHdu {
     let newhdu = hdu.delete_column(&mut fptr, "bar")?;
     # }
     # {
-    # let tdir = tempdir::TempDir::new("fitsio-")?;
+    # let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
     # let mut fptr = fitsio::FitsFile::create(filename).open()?;
@@ -667,7 +667,7 @@ impl FitsHdu {
     # use fitsio::hdu::HduInfo;
     # use fitsio::tables::{ColumnDescription, ColumnDataType};
     # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # let tdir = tempdir::TempDir::new("fitsio-")?;
+    # let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
     # let mut fptr = fitsio::FitsFile::create(filename).open()?;
@@ -702,7 +702,7 @@ impl FitsHdu {
     # use fitsio::hdu::HduInfo;
     # use fitsio::tables::{ColumnDescription, ColumnDataType};
     # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # let tdir = tempdir::TempDir::new("fitsio-")?;
+    # let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
     # let mut fptr = fitsio::FitsFile::create(filename).open()?;
@@ -742,7 +742,7 @@ impl FitsHdu {
     # use fitsio::hdu::HduInfo;
     # use fitsio::tables::{ColumnDescription, ColumnDataType};
     # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # let tdir = tempdir::TempDir::new("fitsio-")?;
+    # let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
     # let mut fptr = fitsio::FitsFile::create(filename).open()?;
@@ -786,7 +786,7 @@ impl FitsHdu {
     # use fitsio::hdu::HduInfo;
     # use fitsio::tables::{ColumnDescription, ColumnDataType};
     # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # let tdir = tempdir::TempDir::new("fitsio-")?;
+    # let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
     # let mut fptr = fitsio::FitsFile::create(filename).open()?;
@@ -852,7 +852,7 @@ impl FitsHdu {
     ```rust
     # use fitsio::images::{ImageDescription, ImageType};
     # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # let tdir = tempdir::TempDir::new("fitsio-")?;
+    # let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
     # let tdir_path = tdir.path();
     # let filename = tdir_path.join("test.fits");
     # let mut fptr = fitsio::FitsFile::create(filename).open()?;

--- a/fitsio/src/lib.rs
+++ b/fitsio/src/lib.rs
@@ -60,7 +60,7 @@ Alternatively a new file can be created on disk with the companion method
 
 ```rust
 # fn try_main() -> Result<(), Box<std::error::Error>> {
-# let tdir = tempdir::TempDir::new("fitsio-")?;
+# let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
 # let tdir_path = tdir.path();
 # let filename = tdir_path.join("test.fits");
 use fitsio::FitsFile;
@@ -87,7 +87,7 @@ example of not adding a custom primary HDU is shown above. Below we see an examp
 
 ```rust
 # fn try_main() -> Result<(), Box<std::error::Error>> {
-# let tdir = tempdir::TempDir::new("fitsio-")?;
+# let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
 # let tdir_path = tdir.path();
 # let filename = tdir_path.join("test.fits");
 use fitsio::FitsFile;
@@ -209,7 +209,7 @@ the desired image:
 
 ```rust
 # fn try_main() -> Result<(), Box<std::error::Error>> {
-# let tdir = tempdir::TempDir::new("fitsio-")?;
+# let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
 # let tdir_path = tdir.path();
 # let filename = tdir_path.join("test.fits");
 # let mut fptr = fitsio::FitsFile::create(filename).open()?;
@@ -236,7 +236,7 @@ name, and a slice of [`ColumnDescription`][column-description]s:
 
 ```rust
 # fn try_main() -> Result<(), Box<std::error::Error>> {
-# let tdir = tempdir::TempDir::new("fitsio-")?;
+# let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
 # let tdir_path = tdir.path();
 # let filename = tdir_path.join("test.fits");
 # let mut fptr = fitsio::FitsFile::create(filename).open()?;
@@ -314,7 +314,7 @@ requires another open [`FitsFile`][fits-file] object to copy to:
 # let filename = "../testdata/full_example.fits";
 # let mut src_fptr = fitsio::FitsFile::open(filename)?;
 #
-# let tdir = tempdir::TempDir::new("fitsio-")?;
+# let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
 # let tdir_path = tdir.path();
 # let filename = tdir_path.join("test.fits");
 # let mut dest_fptr = fitsio::FitsFile::create(filename).open()?;
@@ -335,7 +335,7 @@ this is called.
 ```rust
 # use fitsio::images::{ImageType, ImageDescription};
 # fn try_main() -> Result<(), Box<std::error::Error>> {
-# let tdir = tempdir::TempDir::new("fitsio-")?;
+# let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
 # let tdir_path = tdir.path();
 # let filename = tdir_path.join("test.fits");
 # let mut fptr = fitsio::FitsFile::create(filename).open()?;
@@ -403,7 +403,7 @@ Header cards can be written through the method
 
 ```rust
 # fn try_main() -> Result<(), Box<std::error::Error>> {
-# let tdir = tempdir::TempDir::new("fitsio-")?;
+# let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
 # let tdir_path = tdir.path();
 # let filename = tdir_path.join("test.fits");
 # {
@@ -616,7 +616,7 @@ memory storage method (e.g. `Vec`) can be passed.
 # use fitsio::images::{ImageType, ImageDescription};
 #
 # fn try_main() -> Result<(), Box<std::error::Error>> {
-# let tdir = tempdir::TempDir::new("fitsio-")?;
+# let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
 # let tdir_path = tdir.path();
 # let filename = tdir_path.join("test.fits");
 # let mut fptr = fitsio::FitsFile::create(filename).open()?;
@@ -639,7 +639,7 @@ the data is to be written, and the data to write.
 # use fitsio::images::{ImageType, ImageDescription};
 #
 # fn try_main() -> Result<(), Box<std::error::Error>> {
-# let tdir = tempdir::TempDir::new("fitsio-")?;
+# let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
 # let tdir_path = tdir.path();
 # let filename = tdir_path.join("test.fits");
 # let mut fptr = fitsio::FitsFile::create(filename).open()?;
@@ -666,7 +666,7 @@ image. If more data is passed than pixels in the image, the method returns with 
 # use fitsio::images::{ImageType, ImageDescription};
 #
 # fn try_main() -> Result<(), Box<std::error::Error>> {
-# let tdir = tempdir::TempDir::new("fitsio-")?;
+# let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
 # let tdir_path = tdir.path();
 # let filename = tdir_path.join("test.fits");
 # let mut fptr = fitsio::FitsFile::create(filename).open()?;
@@ -695,7 +695,7 @@ again. This ensures the image changes are reflected in the hew HDU object.
 ```rust
 # use std::fs::copy;
 # fn try_main() -> Result<(), Box<std::error::Error>> {
-# let tdir = tempdir::TempDir::new("fitsio-")?;
+# let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
 # let tdir_path = tdir.path();
 # let filename = tdir_path.join("test.fits");
 # copy("../testdata/full_example.fits", &filename)?;
@@ -738,7 +738,7 @@ than the table length.
 # use fitsio::hdu::HduInfo;
 # use fitsio::tables::{ColumnDescription, ColumnDataType};
 # fn try_main() -> Result<(), Box<std::error::Error>> {
-# let tdir = tempdir::TempDir::new("fitsio-")?;
+# let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
 # let tdir_path = tdir.path();
 # let filename = tdir_path.join("test.fits");
 # let mut fptr = fitsio::FitsFile::create(filename).open()?;
@@ -767,7 +767,7 @@ range is inclusive of both the upper and lower bounds, so `0..4` writes 5 elemen
 # use fitsio::hdu::HduInfo;
 # use fitsio::tables::{ColumnDescription, ColumnDataType};
 # fn try_main() -> Result<(), Box<std::error::Error>> {
-# let tdir = tempdir::TempDir::new("fitsio-")?;
+# let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
 # let tdir_path = tdir.path();
 # let filename = tdir_path.join("test.fits");
 # let mut fptr = fitsio::FitsFile::create(filename).open()?;
@@ -799,7 +799,7 @@ preferred as it does not require shifting of data within the file.
 use fitsio::tables::{ColumnDescription, ColumnDataType};
 
 # fn try_main() -> Result<(), Box<std::error::Error>> {
-# let tdir = tempdir::TempDir::new("fitsio-")?;
+# let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
 # let tdir_path = tdir.path();
 # let filename = tdir_path.join("test.fits");
 # let mut fptr = fitsio::FitsFile::create(filename).open()?;
@@ -827,7 +827,7 @@ The column can either be accessed by integer or name
 # use fitsio::tables::{ColumnDescription, ColumnDataType};
 # fn try_main() -> Result<(), Box<std::error::Error>> {
 # {
-# let tdir = tempdir::TempDir::new("fitsio-")?;
+# let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
 # let tdir_path = tdir.path();
 # let filename = tdir_path.join("test.fits");
 # let mut fptr = fitsio::FitsFile::create(filename).open()?;
@@ -840,7 +840,7 @@ The column can either be accessed by integer or name
 let newhdu = hdu.delete_column(&mut fptr, "bar")?;
 # }
 # {
-# let tdir = tempdir::TempDir::new("fitsio-")?;
+# let tdir = tempfile::Builder::new().prefix("fitsio-").tempdir().unwrap();
 # let tdir_path = tdir.path();
 # let filename = tdir_path.join("test.fits");
 # let mut fptr = fitsio::FitsFile::create(filename).open()?;

--- a/fitsio/src/testhelpers.rs
+++ b/fitsio/src/testhelpers.rs
@@ -1,11 +1,12 @@
 use std::{f32, f64};
+use tempfile::Builder;
 
 /// Function to allow access to a temporary file
 pub(crate) fn with_temp_file<F>(callback: F)
 where
     F: for<'a> Fn(&'a str),
 {
-    let tdir = tempdir::TempDir::new("fitsio-").unwrap();
+    let tdir = Builder::new().prefix("fitsio-").tempdir().unwrap();
     let tdir_path = tdir.path();
     let filename = tdir_path.join("test.fits");
 


### PR DESCRIPTION
Replace the deprecated package `tempdir` with the new `tempfile` package, which supports the functionality that we require.