### PR TITLE
Use workspace

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { rust: stable }
-          - { rust: nightly }
+          - { test: basic, rust: stable }
+          - { test: bindgen, rust: stable }
+          - { test: full_example, rust: stable }
+          - { test: feature_array, rust: stable }
+          - { test: feature_fitsio_src, rust: stable }
+          - { test: book_examples, rust: stable }
+          - { test: basic, rust: nightly }
+          - { test: bindgen, rust: nightly }
+          - { test: full_example, rust: nightly }
+          - { test: feature_array, rust: nightly }
+          - { test: feature_fitsio_src, rust: nightly }
+          - { test: book_examples, rust: nightly }
     steps:
       - name: Checkout sources
         uses: actions/checkout@v1
@@ -39,6 +49,7 @@ jobs:
         run: bash ./bin/test
         env:
           RUST_VERSION: ${{matrix.rust}}
+          TEST_TO_RUN: ${{matrix.test}}
 
   macos-test:
     runs-on: macos-latest
@@ -46,8 +57,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { rust: stable }
-          - { rust: nightly }
+          - { test: basic, rust: stable }
+          - { test: bindgen, rust: stable }
+          - { test: full_example, rust: stable }
+          - { test: feature_array, rust: stable }
+          - { test: feature_fitsio_src, rust: stable }
+          - { test: book_examples, rust: stable }
+          - { test: basic, rust: nightly }
+          - { test: bindgen, rust: nightly }
+          - { test: full_example, rust: nightly }
+          - { test: feature_array, rust: nightly }
+          - { test: feature_fitsio_src, rust: nightly }
+          - { test: book_examples, rust: nightly }
     steps:
       - name: Checkout sources
         uses: actions/checkout@v1
@@ -68,3 +89,4 @@ jobs:
         run: bash ./bin/test
         env:
           RUST_VERSION: ${{matrix.rust}}
+          TEST_TO_RUN: ${{matrix.test}}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,8 @@
+[workspace]
+
+members = [
+    "fitsio",
+    "fitsio-sys",
+    "fitsio-derive",
+    "fitsio-sys-bindgen",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ members = [
     "fitsio-sys",
     "fitsio-derive",
     "fitsio-sys-bindgen",
+    "homepage/fitsioexample",
 ]

--- a/bin/test
+++ b/bin/test
@@ -12,7 +12,6 @@ export CARGO_TARGET_DIR=target
 
 # Test workspace
 run_cargo clean
-run_cargo clippy -- -D warnings
 run_cargo test
 
 # Test the bindgen feature

--- a/bin/test
+++ b/bin/test
@@ -8,28 +8,17 @@ run_cargo() {
     cargo +${RUST_VERSION} $*
 }
 
-export CARGO_TARGET_DIR=target
+TEST_TO_RUN=${TEST_TO_RUN:all}
 
-# Test workspace
-run_cargo clean
-run_cargo test
+run_test() {
+    if [ "${TEST_TO_RUN}" = "$1" ] || [ "{TEST_TO_RUN}" = "all" ]; then
+        bash "./bin/test_$1"
+    fi
+}
 
-# Test the bindgen feature
-run_cargo clean --manifest-path fitsio/Cargo.toml
-run_cargo test --manifest-path fitsio/Cargo.toml --features bindgen --no-default-features
-
-# Test the full example
-run_cargo clean --manifest-path fitsio/Cargo.toml
-run_cargo run --manifest-path fitsio/Cargo.toml --example full_example
-
-# Test the array feature
-run_cargo clean --manifest-path fitsio/Cargo.toml
-run_cargo test --manifest-path fitsio/Cargo.toml --features array
-
-# Test the fitsio-src feature
-run_cargo clean --manifest-path fitsio/Cargo.toml
-run_cargo test --manifest-path fitsio/Cargo.toml --features fitsio-src
-
-# Compile the book examples
-run_cargo clean --manifest-path homepage/fitsioexample/Cargo.toml
-run_cargo build --manifest-path homepage/fitsioexample/Cargo.toml --bins
+run_test basic
+run_test bindgen
+run_test full_example
+run_test feature_array
+run_test feature_fitsio_src
+run_test book_examples

--- a/bin/test
+++ b/bin/test
@@ -5,29 +5,15 @@ set -x
 RUST_VERSION=${RUST_VERSION:-stable}
 
 run_cargo() {
-    if [ -z $TRAVIS ]; then
-        # Not running on travis
-        cargo +${RUST_VERSION} $*
-    else
-        # Running on travis
-        cargo $*
-    fi
+    cargo +${RUST_VERSION} $*
 }
 
 export CARGO_TARGET_DIR=target
 
-for toml in $(find . -maxdepth 2 -name "Cargo.toml"); do
-    run_cargo clean --manifest-path $toml
-    # Run clippy
-    # only convert warnings to errors if the project is not fitsio-sys-bindgen,
-    # as this contains converted code (from bindgen) which we do not control.
-    grep -q fitsio-sys $toml && {
-        run_cargo clippy --manifest-path $toml
-    } || {
-        run_cargo clippy --manifest-path $toml -- -D warnings
-    }
-    run_cargo test --manifest-path $toml
-done
+# Test workspace
+run_cargo clean
+run_cargo clippy -- -D warnings
+run_cargo test
 
 # Test the bindgen feature
 run_cargo clean --manifest-path fitsio/Cargo.toml

--- a/bin/test_basic
+++ b/bin/test_basic
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -euo pipefail
+
+RUST_VERSION=${RUST_VERSION:-stable}
+
+run_cargo() {
+    cargo +${RUST_VERSION} $*
+}
+
+# Test workspace
+run_cargo clean
+run_cargo test

--- a/bin/test_bindgen
+++ b/bin/test_bindgen
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -euo pipefail
+
+RUST_VERSION=${RUST_VERSION:-stable}
+
+run_cargo() {
+    cargo +${RUST_VERSION} $*
+}
+
+# Test the bindgen feature
+run_cargo clean --manifest-path fitsio/Cargo.toml
+run_cargo test --manifest-path fitsio/Cargo.toml --features bindgen --no-default-features

--- a/bin/test_book_examples
+++ b/bin/test_book_examples
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -euo pipefail
+
+RUST_VERSION=${RUST_VERSION:-stable}
+
+run_cargo() {
+    cargo +${RUST_VERSION} $*
+}
+
+# Compile the book examples
+run_cargo clean --manifest-path homepage/fitsioexample/Cargo.toml
+run_cargo build --manifest-path homepage/fitsioexample/Cargo.toml --bins

--- a/bin/test_feature_array
+++ b/bin/test_feature_array
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -euo pipefail
+
+RUST_VERSION=${RUST_VERSION:-stable}
+
+run_cargo() {
+    cargo +${RUST_VERSION} $*
+}
+
+# Test the array feature
+run_cargo clean --manifest-path fitsio/Cargo.toml
+run_cargo test --manifest-path fitsio/Cargo.toml --features array
+

--- a/bin/test_feature_fitsio_src
+++ b/bin/test_feature_fitsio_src
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -euo pipefail
+
+RUST_VERSION=${RUST_VERSION:-stable}
+
+run_cargo() {
+    cargo +${RUST_VERSION} $*
+}
+
+# Test the fitsio-src feature
+run_cargo clean --manifest-path fitsio/Cargo.toml
+run_cargo test --manifest-path fitsio/Cargo.toml --features fitsio-src
+

--- a/bin/test_full_example
+++ b/bin/test_full_example
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -euo pipefail
+
+RUST_VERSION=${RUST_VERSION:-stable}
+
+run_cargo() {
+    cargo +${RUST_VERSION} $*
+}
+
+# Test the full example
+run_cargo clean --manifest-path fitsio/Cargo.toml
+run_cargo run --manifest-path fitsio/Cargo.toml --example full_example
+

--- a/fitsio/src/ndarray_compat.rs
+++ b/fitsio/src/ndarray_compat.rs
@@ -188,9 +188,7 @@ where
                 let n_rows = n_pixels_requested / width;
                 ReadImage::read_rows(fits_file, hdu, start_pixel, n_rows)
             }
-            HduInfo::TableInfo { .. } => {
-                return Err("Cannot read image data from a FITS table".into());
-            }
+            HduInfo::TableInfo { .. } => Err("Cannot read image data from a FITS table".into()),
             _ => unreachable!(),
         }
     }


### PR DESCRIPTION
Use a rust workspace for the package. This means we can run simple test commands against the whole workspace, rather than the convoluted test script.