### PR TITLE
Fix non-standard include paths

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -38,7 +38,9 @@ class TestRunner:
         self._run_cargo("test")
 
     def _run_test_clippy(self):
-        self._run_cargo("clippy", "--", "-D", "warnings")
+        self._run_cargo(
+            "clippy", "--", "-D", "warnings", "-A", "clippy::non-send-fields-in-send-ty"
+        )
 
     def _run_test_full_example(self):
         self._run_cargo(

--- a/fitsio-sys-bindgen/Cargo.toml
+++ b/fitsio-sys-bindgen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fitsio-sys-bindgen"
 edition = "2018"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Simon Walker <s.r.walker101@googlemail.com>"]
 description = "FFI wrapper around cfitsio"
 homepage = "https://github.com/mindriot101/rust-fitsio"

--- a/fitsio-sys-bindgen/build.rs
+++ b/fitsio-sys-bindgen/build.rs
@@ -7,10 +7,16 @@ use std::path::PathBuf;
 fn main() {
     let package_name = "cfitsio";
     match pkg_config::probe_library(package_name) {
-        Ok(_) => {
+        Ok(lib) => {
+            let include_args: Vec<_> = lib
+                .include_paths
+                .into_iter()
+                .map(|p| format!("-I{}", p.to_str().unwrap()))
+                .collect();
             let bindings = bindgen::builder()
                 .header("wrapper.h")
                 .block_extern_crate(true)
+                .clang_args(include_args)
                 .opaque_type("fitsfile")
                 .opaque_type("FITSfile")
                 .rust_target(RustTarget::Stable_1_0)


### PR DESCRIPTION
New laptop with non-standard install location means our build system has
to be better.