### PR TITLE
Specify required patch versions for all deps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## [Unreleased]
 ### Added
 ### Changed
+
+* Specify version dependencies more specifically which should make installations more reliable, see [this post](https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277/9) [#151](https://github.com/mindriot101/rust-fitsio/pull/151)
+
 ### Removed
 
 ## [0.19.0]

--- a/fitsio-derive/Cargo.toml
+++ b/fitsio-derive/Cargo.toml
@@ -12,8 +12,8 @@ documentation = "https://docs.rs/fitsio-derive"
 categories = ["external-ffi-bindings", "science"]
 
 [dependencies]
-quote = "1"
-syn = { version = "1", features = ["extra-traits"] }
+quote = "1.0.0"
+syn = { version = "1.0.0", features = ["extra-traits"] }
 
 [lib]
 proc-macro = true

--- a/fitsio-sys-bindgen/Cargo.toml
+++ b/fitsio-sys-bindgen/Cargo.toml
@@ -13,15 +13,15 @@ documentation = "https://docs.rs/fitsio-sys-bindgen"
 categories = ["external-ffi-bindings", "science"]
 
 [dependencies]
-libc = "0"
-block = "0"
+libc = "0.1.5"
+block = "0.1.5"
 
 [dev-dependencies]
-tempfile = "3.1.0"
+tempfile = "3.0.0"
 
 [build-dependencies]
-pkg-config = "0"
-bindgen = "0.59"
+pkg-config = "0.3.7"
+bindgen = "0.59.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/fitsio-sys/Cargo.toml
+++ b/fitsio-sys/Cargo.toml
@@ -16,11 +16,8 @@ links = "cfitsio"
 [features]
 fitsio-src = []
 
-[dependencies]
-libc = "0"
-
 [build-dependencies]
-pkg-config = "0"
+pkg-config = "0.3.7"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/fitsio/Cargo.toml
+++ b/fitsio/Cargo.toml
@@ -16,15 +16,15 @@ features = ["array"]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-fitsio-sys = {version = "0", path = "../fitsio-sys", optional = true}
-fitsio-sys-bindgen = {version = "0", path = "../fitsio-sys-bindgen", optional = true}
-libc = "0"
-ndarray = {version = "0", optional = true}
+fitsio-sys = {path = "../fitsio-sys", optional = true}
+fitsio-sys-bindgen = {path = "../fitsio-sys-bindgen", optional = true}
+libc = "0.2.44"
+ndarray = {version = ">=0.8", optional = true}
 
 [dev-dependencies]
-criterion = "0.3.0"
-fitsio-derive = {version = "0", path = "../fitsio-derive"}
-tempfile = "3.1.0"
+criterion = "0.3.5"
+fitsio-derive = {path = "../fitsio-derive"}
+tempfile = "3.0.0"
 version-sync = "0.9.0"
 
 [features]

--- a/homepage/fitsioexample/Cargo.toml
+++ b/homepage/fitsioexample/Cargo.toml
@@ -5,5 +5,5 @@ version = "0.1.0"
 authors = ["Simon Walker <s.r.walker101@googlemail.com>"]
 
 [dependencies]
-fitsio = { version = "*", path = "../../fitsio", features = ["array"]}
-ndarray = "*"
+fitsio = { path = "../../fitsio", features = ["array"] }
+ndarray = ">=0.8"


### PR DESCRIPTION
Hi @mindriot101, hope you're doing well.

I was inspired by a [post](https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277/2) this morning to see if my own crates were behaving with respect to the minimum versions specified for my dependencies.  Needless to say, they were not, but I wasn't the only one!  I've taken an axe to `rust-fitsio` and found what I think are its minimum requirements.  I think it's a pretty innocuous commit, but let me know if there are questions.  With these changes, people can confidently build with `rust-fitsio` knowing that its dependencies are as tightly defined as possible.

Commit message:
Attempting to build/test after running `cargo +nightly -Z
minimal-versions update` will fail, because the dependency versions are
not tight enough. This commit specifies the minimum version of each
dependency that allows builds to succeed and tests to pass.

Note that if ndarray changes its API enough, using new versions of it
will cause fitsio to fail to compile; however, this was always the case
before this commit.