### PR TITLE
Dep versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Changed
 
 * Specify version dependencies more specifically which should make installations more reliable, see [this post](https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277/9) [#151](https://github.com/mindriot101/rust-fitsio/pull/151)
+* Pin `ndarray` against versions 0.15.*. This prevents downstream users from
+  having interoperability problems when `ndarray` updates to 0.16.0.
 
 ### Removed
 

--- a/fitsio-sys-bindgen/Cargo.toml
+++ b/fitsio-sys-bindgen/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/fitsio-sys-bindgen"
 categories = ["external-ffi-bindings", "science"]
 
 [dependencies]
-libc = "0.1.5"
+libc = "0.2.0"
 block = "0.1.5"
 
 [dev-dependencies]

--- a/fitsio/Cargo.toml
+++ b/fitsio/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 fitsio-sys = {path = "../fitsio-sys", optional = true}
 fitsio-sys-bindgen = {path = "../fitsio-sys-bindgen", optional = true}
 libc = "0.2.44"
-ndarray = {version = ">=0.8", optional = true}
+ndarray = {version = "0.15.0", optional = true}
 
 [dev-dependencies]
 criterion = "0.3.5"

--- a/fitsio/src/fitsfile.rs
+++ b/fitsio/src/fitsfile.rs
@@ -354,7 +354,7 @@ impl FitsFile {
                     64 => ImageType::LongLong,
                     -32 => ImageType::Float,
                     -64 => ImageType::Double,
-                    _ => unreachable!(&format!("Unhandled image bitpix type: {}", bitpix)),
+                    _ => unreachable!("{}", format!("Unhandled image bitpix type: {}", bitpix)),
                 };
 
                 HduInfo::ImageInfo {

--- a/homepage/fitsioexample/Cargo.toml
+++ b/homepage/fitsioexample/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Simon Walker <s.r.walker101@googlemail.com>"]
 
 [dependencies]
 fitsio = { path = "../../fitsio", features = ["array"] }
-ndarray = ">=0.8"
+ndarray = "0.15.0"


### PR DESCRIPTION
Hi @mindriot101, me again. The first commit here should help keep dependabot quiet. It was my mistake to pull `libc` down to `0.1.*`; it should've always been something in `0.2.*`.

The second commit also pins us against the most-current version of `ndarray`.  In the `main` branch, the `>=0.8.0` range is not very different from what it used to be (`0`), but this commit solves an important problem; if a new version of `ndarray` (e.g. `0.16.0`) is released and a crate is using both `rust-fitsio` and `ndarray 0.15.*`, `cargo` will eagerly use `ndarray 0.16.0` for `rust-fitsio` and `0.15.*` otherwise, causing interoperability issues. This has caused me great pain in the past (not via `rust-fitsio`, mind you) but I've only relatively recently understood why.

Anyway, let me know what you think!  Cheers.