### PR TITLE
Remove apt-get command for libclang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * Specify version dependencies more specifically which should make installations more reliable, see [this post](https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277/9) [#151](https://github.com/mindriot101/rust-fitsio/pull/151)
 * Pin `ndarray` against versions 0.15.*. This prevents downstream users from
   having interoperability problems when `ndarray` updates to 0.16.0.
+* Remove apt-get command for libclang, which was preventing `fitsio/Dockerfile` from building
 
 ### Removed
 

--- a/fitsio/Dockerfile
+++ b/fitsio/Dockerfile
@@ -5,7 +5,6 @@ RUN apt-get update && \
     apt-get install -yq --no-install-recommends \
         libcfitsio-dev \
         pkg-config \
-        libclang-3.8-dev \
         build-essential \
         clang \
         gdb \


### PR DESCRIPTION
I'm on a Windows development environment, but I thought creating a container would be easier than setting up the prerequisites for building cfitsio from source. I started to build one myself, then found the `fitsio/Dockerfile`, which looks like it already has all of the prereqs, but I was unable to build it without removing the libclang-3.8-dev dependency. This change doesn't seem to break any existing functionality; I was able to run `cargo build --features fitsio-src`, `cargo build --no-default-features --features bindgen`, `cargo test`, and `cargo bench` in the resulting container.