### PR TITLE
fix: update bindgen in fitsio-sys-bindgen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Changed
 
 * Some more types are deriving `Eq` thanks to a clippy lint
+* Fixed broken tests on m1 macos [#174](https://github.com/mindriot101/rust-fitsio/pull/174)
 
 ### Removed
 

--- a/fitsio-sys-bindgen/Cargo.toml
+++ b/fitsio-sys-bindgen/Cargo.toml
@@ -21,7 +21,7 @@ tempfile = "3.0.0"
 
 [build-dependencies]
 pkg-config = "0.3.7"
-bindgen = "0.59.0"
+bindgen = "0.60.1"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
It seems just a version bump was required.

Looks like this PR: https://github.com/rust-lang/rust-bindgen/pull/2203

FIxes #173 