### PR TITLE
fix: include system lib locations in link arguments

### DIFF
--- a/fitsio-sys-bindgen/Cargo.toml
+++ b/fitsio-sys-bindgen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fitsio-sys-bindgen"
 edition = "2018"
-version = "0.0.3"
+version = "0.0.4"
 authors = ["Simon Walker <s.r.walker101@googlemail.com>"]
 description = "FFI wrapper around cfitsio"
 homepage = "https://github.com/mindriot101/rust-fitsio"

--- a/fitsio-sys-bindgen/build.rs
+++ b/fitsio-sys-bindgen/build.rs
@@ -6,7 +6,10 @@ use std::path::PathBuf;
 
 fn main() {
     let package_name = "cfitsio";
-    match pkg_config::probe_library(package_name) {
+    let mut config = pkg_config::Config::new();
+    config.print_system_libs(true);
+    config.print_system_cflags(true);
+    match config.probe(package_name) {
         Ok(lib) => {
             let include_args: Vec<_> = lib
                 .include_paths

--- a/fitsio-sys/Cargo.toml
+++ b/fitsio-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fitsio-sys"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2018"
 authors = ["Simon Walker <s.r.walker101@googlemail.com>"]
 description = "FFI wrapper around cfitsio"

--- a/fitsio-sys/build.rs
+++ b/fitsio-sys/build.rs
@@ -4,7 +4,10 @@ fn bind_cfitsio() {
     use std::io::Write;
 
     let package_name = "cfitsio";
-    match pkg_config::probe_library(package_name) {
+    let mut config = pkg_config::Config::new();
+    config.print_system_libs(true);
+    config.print_system_cflags(true);
+    match config.probe(package_name) {
         Ok(_) => {}
         Err(Error::Failure { output, .. }) => {
             // Handle the case where the user has not installed cfitsio, and thusly it is not on

--- a/fitsio/Cargo.toml
+++ b/fitsio/Cargo.toml
@@ -16,8 +16,8 @@ features = ["array"]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-fitsio-sys = {version = "0.4.0", path = "../fitsio-sys", optional = true}
-fitsio-sys-bindgen = {version = "0.0.3", path = "../fitsio-sys-bindgen", optional = true}
+fitsio-sys = {version = "0.4.1", path = "../fitsio-sys", optional = true}
+fitsio-sys-bindgen = {version = "0.0.4", path = "../fitsio-sys-bindgen", optional = true}
 libc = "0.2.44"
 ndarray = {version = "0.15.0", optional = true}
 


### PR DESCRIPTION
This is so we don't _have_ to assume the package is on the system path,
and we link to libraries in that location explicitly.

closes #182
